### PR TITLE
Feat: Secondary routes and analysis

### DIFF
--- a/lib/Horde/Routes/Mapper.php
+++ b/lib/Horde/Routes/Mapper.php
@@ -314,6 +314,108 @@ class Horde_Routes_Mapper
     }
 
     /**
+     * Connect a secondary/legacy route that matches but doesn't generate
+     *
+     * Secondary routes are useful for supporting alternative URLs (e.g., during
+     * migration from legacy URL schemes) without affecting canonical URL generation.
+     *
+     * Usage:
+     *   // Primary route (used for generation)
+     *   $m->connect('api/users/:id', array('middleware' => array('ApiAuth')));
+     *
+     *   // Secondary routes (match only, not generated) - e.g., legacy URLs
+     *   $m->connectSecondary('user/:id', array('middleware' => array('ApiAuth')));
+     *   $m->connectSecondary('profile/:id', array('middleware' => array('ApiAuth')));
+     *
+     * Note: Designed for modern PSR-7/PSR-15 applications using Horde\Http\Server.
+     * For legacy Horde_Controller applications, consider migrating to PSR-15.
+     * See: horde-development/libraries/controller/controller-deprecation-notice.md
+     *
+     * @param  mixed  $first   First argument (route name or path)
+     * @param  mixed  $second  Second argument (path or kargs)
+     * @param  mixed  $third   Third argument (kargs if named route)
+     * @return void
+     */
+    public function connectSecondary($first, $second = null, $third = null)
+    {
+        // Parse arguments same as connect()
+        if ($third !== null) {
+            // 3 args: connect('route_name', '/path', array('kargs'=>'here'))
+            $routeName = $first;
+            $routePath = $second;
+            $kargs = $third;
+        } elseif ($second !== null) {
+            if (is_array($second)) {
+                // 2 args: connect('/path', array('kargs'=>'here'))
+                $routeName = null;
+                $routePath = $first;
+                $kargs = $second;
+            } else {
+                // 2 args: connect('route_name', '/path')
+                $routeName = $first;
+                $routePath = $second;
+                $kargs = array();
+            }
+        } else {
+            // 1 arg: connect('/path')
+            $routeName = null;
+            $routePath = $first;
+            $kargs = array();
+        }
+
+        // Mark as secondary
+        $kargs['_secondary'] = true;
+
+        // Use existing connect logic
+        if ($routeName === null) {
+            $this->connect($routePath, $kargs);
+        } else {
+            $this->connect($routeName, $routePath, $kargs);
+        }
+    }
+
+    /**
+     * Get list of all routes with metadata
+     *
+     * Returns array of route information including path, name, type (primary/secondary),
+     * static flag, defaults, and conditions. Useful for debugging and route documentation.
+     *
+     * Example return:
+     *   array(
+     *     array('path' => 'api/users/:id', 'name' => 'api_user', 'type' => 'primary', ...),
+     *     array('path' => 'user/:id', 'name' => null, 'type' => 'secondary', ...),
+     *   )
+     *
+     * @return array Array of route metadata arrays
+     */
+    public function getRouteList()
+    {
+        $routes = array();
+
+        foreach ($this->matchList as $route) {
+            // Find the route name if it exists
+            $name = null;
+            foreach ($this->_routeNames as $routeName => $routeObj) {
+                if ($routeObj === $route) {
+                    $name = $routeName;
+                    break;
+                }
+            }
+
+            $routes[] = array(
+                'path' => $route->routePath,
+                'name' => $name,
+                'type' => $route->secondary ? 'secondary' : 'primary',
+                'static' => $route->static,
+                'defaults' => $route->defaults,
+                'conditions' => $route->conditions,
+            );
+        }
+
+        return $routes;
+    }
+
+    /**
      * Set an optional Horde_Cache object for the created rules.
      *
      * @param Horde_Cache $cache Cache object
@@ -349,7 +451,7 @@ class Horde_Routes_Mapper
 
         // Assemble all the hardcoded/defaulted actions/controllers used
         foreach ($this->matchList as $route) {
-            if ($route->static) {
+            if ($route->static || $route->secondary) {
                 continue;
             }
             if (isset($route->defaults['controller'])) {
@@ -368,7 +470,7 @@ class Horde_Routes_Mapper
         // Otherwise we add it to every hardcode since it can be changed.
         $gendict = array();  // Our generated two-deep hash
         foreach ($this->matchList as $route) {
-            if ($route->static) {
+            if ($route->static || $route->secondary) {
                 continue;
             }
             $clist = $controllerList;

--- a/lib/Horde/Routes/Matcher.php
+++ b/lib/Horde/Routes/Matcher.php
@@ -70,7 +70,23 @@ class Horde_Routes_Matcher
     public function getMatchDict()
     {
         if ($this->_match_dict === null) {
-            $path = $this->_request->getPath();
+            // Auto-populate environ from request
+            if (method_exists($this->_request, 'getMethod')) {
+                $this->_mapper->environ = array('REQUEST_METHOD' => $this->_request->getMethod());
+            }
+
+            // Extract path from request - handle both PSR-7 and Horde_Controller_Request
+            if (method_exists($this->_request, 'getPath')) {
+                // Horde_Controller_Request
+                $path = $this->_request->getPath();
+            } elseif (method_exists($this->_request, 'getUri')) {
+                // PSR-7 ServerRequestInterface
+                $path = $this->_request->getUri()->getPath();
+            } else {
+                throw new RuntimeException('Request must implement getPath() or getUri()');
+            }
+
+            // Strip query string
             if (($pos = strpos($path, '?')) !== false) {
                 $path = substr($path, 0, $pos);
             }

--- a/lib/Horde/Routes/Route.php
+++ b/lib/Horde/Routes/Route.php
@@ -162,6 +162,21 @@ class Horde_Routes_Route
     public $stack;
 
     /**
+     * Is this a secondary/legacy route that matches but doesn't generate?
+     *
+     * Secondary routes are useful for supporting alternative URLs (e.g., legacy
+     * URLs during migration) without affecting URL generation. They participate
+     * in matching but are excluded from the generation dictionary.
+     *
+     * This feature is designed for modern PSR-7/PSR-15 applications using the
+     * Rampage middleware framework (Horde\Http\Server). Legacy Horde_Controller
+     * applications may have limited support.
+     *
+     * @var boolean
+     */
+    public $secondary = false;
+
+    /**
      *  Initialize a route, with a given routepath for matching/generation
      *
      *  The set of keyword args will be used as defaults.
@@ -192,6 +207,10 @@ class Horde_Routes_Route
             $this->stack = $kargs['stack'];
             unset ($kargs['stack']);
         }
+
+        // Secondary routes match but don't generate URLs
+        $this->secondary = isset($kargs['_secondary']) ? $kargs['_secondary'] : false;
+        unset($kargs['_secondary']);
 
         $this->filter = isset($kargs['_filter']) ? $kargs['_filter'] : null;
         unset($kargs['_filter']);

--- a/src/Analysis/RouteAnalysisReport.php
+++ b/src/Analysis/RouteAnalysisReport.php
@@ -1,0 +1,251 @@
+<?php
+/**
+ * Horde Routes package
+ *
+ * @author  Ralf Lang <lang@b1-systems.de>
+ * @license http://www.horde.org/licenses/bsd BSD
+ * @package Routes
+ */
+
+declare(strict_types=1);
+
+namespace Horde\Routes\Analysis;
+
+/**
+ * Route analysis report formatter
+ *
+ * Formats route analysis warnings into human-readable text or machine-readable JSON.
+ * Used to present RouteAnalyzer results to developers or tooling.
+ *
+ * Usage:
+ * <code>
+ * $analyzer = new RouteAnalyzer($mapper);
+ * $warnings = $analyzer->analyze();
+ *
+ * $report = new RouteAnalysisReport($warnings);
+ * echo $report->formatText();  // Human-readable
+ *
+ * // Or for tooling
+ * $json = $report->formatJson();  // Machine-readable
+ * </code>
+ *
+ * @package Routes
+ */
+class RouteAnalysisReport
+{
+    /**
+     * Array of warning objects
+     *
+     * @var array<array<string, mixed>>
+     */
+    private array $warnings;
+
+    /**
+     * Create a new report
+     *
+     * @param array<array<string, mixed>> $warnings Array of warning objects from RouteAnalyzer
+     */
+    public function __construct(array $warnings)
+    {
+        $this->warnings = $warnings;
+    }
+
+    /**
+     * Format warnings as human-readable text
+     *
+     * Returns formatted text with ANSI colors for terminal output.
+     * Includes sections for different warning types and severity indicators.
+     *
+     * @return string Formatted text report
+     */
+    public function formatText(): string
+    {
+        if (empty($this->warnings)) {
+            return "\n✅ \033[32mNo issues found\033[0m - All routes appear to be correctly configured.\n";
+        }
+
+        $output = "\n\033[1m📋 Route Analysis Report\033[0m\n";
+        $output .= str_repeat("=", 60) . "\n\n";
+
+        // Group warnings by type
+        $grouped = [];
+        foreach ($this->warnings as $warning) {
+            $type = $warning['type'] ?? 'unknown';
+            $grouped[$type][] = $warning;
+        }
+
+        // Display each type
+        foreach ($grouped as $type => $warnings) {
+            $output .= $this->formatWarningSection($type, $warnings);
+        }
+
+        // Summary
+        $output .= "\n" . str_repeat("=", 60) . "\n";
+        $output .= sprintf("\n\033[1mTotal Issues:\033[0m %d\n", count($this->warnings));
+
+        // Count by severity
+        $bySeverity = [];
+        foreach ($this->warnings as $warning) {
+            $severity = $warning['severity'] ?? 'warning';
+            $bySeverity[$severity] = ($bySeverity[$severity] ?? 0) + 1;
+        }
+
+        foreach ($bySeverity as $severity => $count) {
+            $color = $severity === 'error' ? '31' : '33';
+            $output .= sprintf("  \033[{$color}m%s:\033[0m %d\n", ucfirst($severity), $count);
+        }
+
+        $output .= "\n";
+
+        return $output;
+    }
+
+    /**
+     * Format a section of warnings by type
+     *
+     * @param string $type Warning type
+     * @param array<array<string, mixed>> $warnings Warnings of this type
+     * @return string Formatted section
+     */
+    private function formatWarningSection(string $type, array $warnings): string
+    {
+        $output = "\033[1m" . ucfirst(str_replace('_', ' ', $type)) . " Issues:\033[0m\n";
+        $output .= str_repeat("-", 60) . "\n";
+
+        foreach ($warnings as $warning) {
+            $output .= $this->formatWarning($warning);
+        }
+
+        $output .= "\n";
+        return $output;
+    }
+
+    /**
+     * Format a single warning
+     *
+     * @param array<string, mixed> $warning Warning object
+     * @return string Formatted warning
+     */
+    private function formatWarning(array $warning): string
+    {
+        $type = $warning['type'] ?? 'unknown';
+        $severity = $warning['severity'] ?? 'warning';
+        $severityColor = $severity === 'error' ? '31' : '33';
+        $severityIcon = $severity === 'error' ? '❌' : '⚠️';
+
+        $output = "\n{$severityIcon} \033[{$severityColor}m" . strtoupper($severity) . "\033[0m\n";
+        $output .= "   " . ($warning['message'] ?? 'Unknown issue') . "\n";
+
+        // Type-specific details
+        switch ($type) {
+            case 'shadowed':
+                $output .= "\n";
+                $output .= "   \033[1mShadowed route:\033[0m  " . ($warning['shadowed_route'] ?? 'unknown') . "\n";
+                $output .= "   \033[1mShadowing route:\033[0m " . ($warning['shadowing_route'] ?? 'unknown') . "\n";
+                if (isset($warning['test_url'])) {
+                    $output .= "   \033[1mTest URL:\033[0m        " . $warning['test_url'] . "\n";
+                }
+                if (isset($warning['matched_route'])) {
+                    $output .= "   \033[1mActually matched:\033[0m " . $warning['matched_route'] . "\n";
+                }
+                break;
+
+            case 'invalid_requirement':
+                $output .= "\n";
+                $output .= "   \033[1mRoute:\033[0m      " . ($warning['route'] ?? 'unknown') . "\n";
+                $output .= "   \033[1mParameter:\033[0m  " . ($warning['parameter'] ?? 'unknown') . "\n";
+                $output .= "   \033[1mPattern:\033[0m    " . ($warning['pattern'] ?? 'unknown') . "\n";
+                if (isset($warning['error'])) {
+                    $output .= "   \033[1mError:\033[0m      " . $warning['error'] . "\n";
+                }
+                break;
+
+            case 'duplicate':
+                $output .= "\n";
+                $output .= "   \033[1mRoute:\033[0m " . ($warning['route'] ?? 'unknown') . "\n";
+                break;
+
+            default:
+                // Generic warning format
+                foreach ($warning as $key => $value) {
+                    if (!in_array($key, ['type', 'message', 'severity']) && is_scalar($value)) {
+                        $output .= "   \033[1m" . ucfirst(str_replace('_', ' ', $key)) . ":\033[0m " . $value . "\n";
+                    }
+                }
+        }
+
+        return $output;
+    }
+
+    /**
+     * Format warnings as JSON
+     *
+     * Returns machine-readable JSON with all warning details.
+     * Suitable for CI/CD integration and tooling.
+     *
+     * @return string JSON-encoded report
+     */
+    public function formatJson(): string
+    {
+        $report = [
+            'warnings' => $this->serializeWarnings(),
+            'summary' => $this->generateSummary()
+        ];
+
+        return json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+    }
+
+    /**
+     * Serialize warnings for JSON output
+     *
+     * Excludes internal/debug fields and Route objects.
+     *
+     * @return array<array<string, mixed>> Serialized warnings
+     */
+    private function serializeWarnings(): array
+    {
+        $serialized = [];
+
+        foreach ($this->warnings as $warning) {
+            $clean = [];
+
+            // Only include public fields (not internal/debug/object fields)
+            foreach ($warning as $key => $value) {
+                // Skip Route objects and internal debug data
+                if (is_object($value) || $key === 'route_object' || $key === 'internal_data') {
+                    continue;
+                }
+
+                $clean[$key] = $value;
+            }
+
+            $serialized[] = $clean;
+        }
+
+        return $serialized;
+    }
+
+    /**
+     * Generate summary statistics
+     *
+     * @return array<string, mixed> Summary data
+     */
+    private function generateSummary(): array
+    {
+        $summary = [
+            'total' => count($this->warnings),
+            'by_type' => [],
+            'by_severity' => []
+        ];
+
+        foreach ($this->warnings as $warning) {
+            $type = $warning['type'] ?? 'unknown';
+            $severity = $warning['severity'] ?? 'warning';
+
+            $summary['by_type'][$type] = ($summary['by_type'][$type] ?? 0) + 1;
+            $summary['by_severity'][$severity] = ($summary['by_severity'][$severity] ?? 0) + 1;
+        }
+
+        return $summary;
+    }
+}

--- a/src/Analysis/RouteAnalyzer.php
+++ b/src/Analysis/RouteAnalyzer.php
@@ -1,0 +1,541 @@
+<?php
+/**
+ * Horde Routes package
+ *
+ * @author  Ralf Lang <lang@b1-systems.de>
+ * @license http://www.horde.org/licenses/bsd BSD
+ * @package Routes
+ */
+
+declare(strict_types=1);
+
+namespace Horde\Routes\Analysis;
+
+use Horde\Routes\Mapper;
+use Horde\Routes\Route;
+
+/**
+ * Runtime route analyzer for detecting configuration issues
+ *
+ * Analyzes route configurations by generating test URLs and verifying which
+ * routes match. This runtime verification approach avoids false positives
+ * from static regex analysis.
+ *
+ * DESIGN PHILOSOPHY:
+ *
+ * This analyzer follows a "progressive enhancement" philosophy:
+ * - It will find REAL problems when they exist
+ * - It will NEVER report false positives (problems that don't exist)
+ * - It may not find EVERY problem (some edge cases may be missed)
+ * - This is intentional and acceptable
+ *
+ * The analyzer may remain incomplete forever, and that's OK. Better to miss
+ * some issues than to waste developer time investigating non-existent problems.
+ * When in doubt, the analyzer stays silent rather than guessing.
+ *
+ * Runtime verification ensures reported issues are actual routing problems,
+ * not theoretical possibilities from regex pattern analysis.
+ *
+ * Detects:
+ * - Shadowed/unreachable routes (later route never matches)
+ * - Invalid regex patterns in requirements
+ * - Duplicate route definitions
+ *
+ * May miss:
+ * - Complex subdomain interactions
+ * - Custom function conditions
+ * - Some edge cases with requirement patterns
+ *
+ * Usage:
+ * <code>
+ * $mapper = new Mapper();
+ * // ... configure routes ...
+ *
+ * $analyzer = new RouteAnalyzer($mapper);
+ * $warnings = $analyzer->analyze();
+ *
+ * if (!empty($warnings)) {
+ *     $report = new RouteAnalysisReport($warnings);
+ *     echo $report->formatText();
+ * }
+ * </code>
+ *
+ * @package Routes
+ */
+class RouteAnalyzer
+{
+    /**
+     * The Mapper to analyze
+     */
+    private Mapper $mapper;
+
+    /**
+     * Verbose output mode
+     */
+    private bool $verbose;
+
+    /**
+     * Generated test URLs for debugging
+     *
+     * @var array<string>
+     */
+    private array $testUrls = [];
+
+    /**
+     * Create a new route analyzer
+     *
+     * @param Mapper $mapper The mapper to analyze
+     * @param bool $verbose Enable verbose output
+     */
+    public function __construct(Mapper $mapper, bool $verbose = false)
+    {
+        $this->mapper = $mapper;
+        $this->verbose = $verbose;
+    }
+
+    /**
+     * Analyze routes and return warnings
+     *
+     * @return array<array<string, mixed>> Array of warning objects
+     */
+    public function analyze(): array
+    {
+        $warnings = [];
+
+        // Ensure routes have regexp generated (needed for matching)
+        $this->ensureRouteRegexps();
+
+        // Check for invalid regex patterns first
+        $warnings = array_merge($warnings, $this->checkInvalidRequirements());
+
+        // Check for exact duplicates
+        $warnings = array_merge($warnings, $this->checkDuplicates());
+
+        // Check for shadowing using runtime verification
+        $warnings = array_merge($warnings, $this->checkShadowing());
+
+        return $warnings;
+    }
+
+    /**
+     * Ensure all routes have their regexps generated
+     *
+     * @return void
+     */
+    private function ensureRouteRegexps(): void
+    {
+        // Get controller list (or use empty array if no scan function)
+        $clist = [];
+        if ($this->mapper->controllerScan !== null) {
+            if ($this->mapper->directory === null) {
+                $clist = call_user_func($this->mapper->controllerScan);
+            } else {
+                $clist = call_user_func($this->mapper->controllerScan, $this->mapper->directory);
+            }
+        }
+
+        // Generate regexp for all routes
+        foreach ($this->mapper->matchList as $route) {
+            if (!$route->static) {
+                $route->makeRegexp($clist);
+            }
+        }
+    }
+
+    /**
+     * Get generated test URLs (for debugging)
+     *
+     * Generates test URLs if not already generated.
+     *
+     * @return array<string> Array of test URLs
+     */
+    public function getTestUrls(): array
+    {
+        // Generate test URLs if not already done
+        if (empty($this->testUrls)) {
+            $this->generateAllTestUrls();
+        }
+
+        return $this->testUrls;
+    }
+
+    /**
+     * Generate all test URLs for all routes
+     *
+     * @return void
+     */
+    private function generateAllTestUrls(): void
+    {
+        foreach ($this->mapper->matchList as $index => $route) {
+            if ($route->static) {
+                continue;
+            }
+
+            $tests = $this->generateTestsForRoute($route);
+            foreach ($tests as $test) {
+                $this->testUrls[] = $test['url'];
+            }
+        }
+    }
+
+    /**
+     * Check for invalid regex patterns in requirements
+     *
+     * @return array<array<string, mixed>> Array of warnings
+     */
+    private function checkInvalidRequirements(): array
+    {
+        $warnings = [];
+
+        foreach ($this->mapper->matchList as $route) {
+            if (empty($route->reqs)) {
+                continue;
+            }
+
+            foreach ($route->reqs as $param => $pattern) {
+                // Test if regex is valid
+                $testPattern = '/' . $pattern . '/';
+                $result = @preg_match($testPattern, '');
+
+                if ($result === false) {
+                    $error = error_get_last();
+                    $warnings[] = [
+                        'type' => 'invalid_requirement',
+                        'message' => 'Invalid regex pattern in requirement',
+                        'route' => $route->routePath,
+                        'parameter' => $param,
+                        'pattern' => $pattern,
+                        'error' => $error['message'] ?? 'Unknown error',
+                        'severity' => 'error'
+                    ];
+                }
+            }
+        }
+
+        return $warnings;
+    }
+
+    /**
+     * Check for duplicate route definitions
+     *
+     * @return array<array<string, mixed>> Array of warnings
+     */
+    private function checkDuplicates(): array
+    {
+        $warnings = [];
+        $seen = [];
+
+        foreach ($this->mapper->matchList as $route) {
+            // Create signature from path, conditions, and requirements
+            $signature = $this->getRouteSignature($route);
+
+            if (isset($seen[$signature])) {
+                $warnings[] = [
+                    'type' => 'duplicate',
+                    'message' => 'Duplicate route definition',
+                    'route' => $route->routePath,
+                    'severity' => 'warning'
+                ];
+            } else {
+                $seen[$signature] = true;
+            }
+        }
+
+        return $warnings;
+    }
+
+    /**
+     * Get unique signature for a route
+     *
+     * @param Route $route Route to get signature for
+     * @return string Unique signature
+     */
+    private function getRouteSignature(Route $route): string
+    {
+        $parts = [
+            'path' => $route->routePath,
+            'conditions' => $route->conditions ?? [],
+            'requirements' => $route->reqs ?? []
+        ];
+
+        return md5(serialize($parts));
+    }
+
+    /**
+     * Check for shadowing using runtime verification
+     *
+     * @return array<array<string, mixed>> Array of warnings
+     */
+    private function checkShadowing(): array
+    {
+        $warnings = [];
+
+        // Generate test URLs for each route
+        $routeTests = $this->generateRouteTests();
+
+        // For each route, test its URLs to see if it's reachable
+        foreach ($routeTests as $routeIndex => $tests) {
+            $route = $this->mapper->matchList[$routeIndex];
+
+            foreach ($tests as $test) {
+                $testUrl = $test['url'];
+                $environ = $test['environ'];
+
+                // Add to test URLs collection
+                if (!in_array($testUrl, $this->testUrls)) {
+                    $this->testUrls[] = $testUrl;
+                }
+
+                // Save original environ
+                $originalEnviron = $this->mapper->environ;
+
+                // Set test environ
+                $this->mapper->environ = $environ;
+
+                // Test which route matches
+                $matchedRoute = $this->findMatchingRoute($testUrl);
+
+                // Restore environ
+                $this->mapper->environ = $originalEnviron;
+
+                // If a different route matched, this route is shadowed
+                if ($matchedRoute !== null && $matchedRoute !== $routeIndex) {
+                    $shadowingRoute = $this->mapper->matchList[$matchedRoute];
+
+                    $warnings[] = [
+                        'type' => 'shadowed',
+                        'message' => 'Route is unreachable due to earlier route',
+                        'shadowed_route' => $route->routePath,
+                        'shadowing_route' => $shadowingRoute->routePath,
+                        'test_url' => $testUrl,
+                        'matched_route' => $shadowingRoute->routePath,
+                        'severity' => 'error'
+                    ];
+
+                    // Only report once per route
+                    break;
+                }
+            }
+        }
+
+        return $warnings;
+    }
+
+    /**
+     * Generate test cases for all routes
+     *
+     * @return array<int, array<array<string, mixed>>> Array indexed by route index
+     */
+    private function generateRouteTests(): array
+    {
+        $tests = [];
+
+        foreach ($this->mapper->matchList as $index => $route) {
+            if ($route->static) {
+                continue; // Skip static routes
+            }
+
+            $tests[$index] = $this->generateTestsForRoute($route);
+        }
+
+        return $tests;
+    }
+
+    /**
+     * Generate test cases for a single route
+     *
+     * @param Route $route Route to generate tests for
+     * @return array<array<string, mixed>> Array of test cases
+     */
+    private function generateTestsForRoute(Route $route): array
+    {
+        $tests = [];
+
+        // Generate multiple test URLs with different value types
+        $variants = [
+            ['numeric' => true],
+            ['alpha' => true],
+            ['mixed' => true]
+        ];
+
+        foreach ($variants as $variant) {
+            $url = $this->generateTestUrl($route, $variant);
+            $environ = $this->generateTestEnviron($route);
+
+            $tests[] = [
+                'url' => $url,
+                'environ' => $environ
+            ];
+        }
+
+        return $tests;
+    }
+
+    /**
+     * Generate a test URL for a route
+     *
+     * @param Route $route Route to generate URL for
+     * @param array<string, bool> $options Generation options
+     * @return string Generated URL
+     */
+    private function generateTestUrl(Route $route, array $options = []): string
+    {
+        $path = $route->routePath;
+
+        // Replace placeholders with test values
+        $path = preg_replace_callback('/:([a-zA-Z_][a-zA-Z0-9_]*)/', function($matches) use ($route, $options) {
+            $param = $matches[1];
+
+            // Check if there's a requirement for this parameter
+            if (isset($route->reqs[$param])) {
+                return $this->generateValueFromRequirement($route->reqs[$param], $options);
+            }
+
+            // Generate default test value based on parameter name
+            return $this->generateDefaultValue($param, $options);
+        }, $path);
+
+        // Ensure leading slash
+        if (!str_starts_with($path, '/')) {
+            $path = '/' . $path;
+        }
+
+        return $path;
+    }
+
+    /**
+     * Generate a value matching a requirement pattern
+     *
+     * @param string $pattern Regex pattern
+     * @param array<string, bool> $options Generation options
+     * @return string Generated value
+     */
+    private function generateValueFromRequirement(string $pattern, array $options): string
+    {
+        // Handle common patterns
+        if ($pattern === '\d+') {
+            return '123';
+        }
+
+        if (preg_match('/^\\\d\{(\d+)\}$/', $pattern, $matches)) {
+            $length = (int)$matches[1];
+            return str_repeat('1', $length);
+        }
+
+        if (preg_match('/^\\\d\{(\d+),(\d+)\}$/', $pattern, $matches)) {
+            $minLength = (int)$matches[1];
+            return str_repeat('1', $minLength);
+        }
+
+        if ($pattern === '[a-z]+' || $pattern === '[a-zA-Z]+') {
+            return isset($options['numeric']) ? 'abc' : 'test';
+        }
+
+        if (preg_match('/^\[a-z\]\[a-z0-9-\]\*$/', $pattern)) {
+            return 'test-slug';
+        }
+
+        // Default numeric value
+        return '123';
+    }
+
+    /**
+     * Generate a default value for a parameter
+     *
+     * @param string $param Parameter name
+     * @param array<string, bool> $options Generation options
+     * @return string Generated value
+     */
+    private function generateDefaultValue(string $param, array $options): string
+    {
+        // Parameter name-based heuristics
+        if (in_array($param, ['id', 'user_id', 'post_id', 'comment_id'])) {
+            return isset($options['numeric']) ? '123' : (isset($options['alpha']) ? '456' : '789');
+        }
+
+        if (in_array($param, ['slug', 'name', 'title'])) {
+            return isset($options['numeric']) ? 'test-slug' : (isset($options['alpha']) ? 'another-slug' : 'third-slug');
+        }
+
+        if ($param === 'action') {
+            return isset($options['numeric']) ? 'show' : (isset($options['alpha']) ? 'edit' : 'delete');
+        }
+
+        if ($param === 'controller') {
+            return 'Test';
+        }
+
+        if ($param === 'year') {
+            return '2024';
+        }
+
+        if ($param === 'month') {
+            return '12';
+        }
+
+        if ($param === 'day') {
+            return '25';
+        }
+
+        // Default value
+        return isset($options['numeric']) ? '123' : (isset($options['alpha']) ? 'test' : 'value');
+    }
+
+    /**
+     * Generate test environment for a route
+     *
+     * @param Route $route Route to generate environ for
+     * @return array<string, mixed> Test environment
+     */
+    private function generateTestEnviron(Route $route): array
+    {
+        $environ = [];
+
+        // Set HTTP method from conditions
+        if (isset($route->conditions['method'])) {
+            $methods = $route->conditions['method'];
+            $environ['REQUEST_METHOD'] = is_array($methods) ? $methods[0] : $methods;
+        } else {
+            $environ['REQUEST_METHOD'] = 'GET';
+        }
+
+        // Set subdomain from conditions
+        if (isset($route->conditions['subdomain'])) {
+            $environ['HTTP_HOST'] = $route->conditions['subdomain'] . '.example.com';
+        }
+
+        return $environ;
+    }
+
+    /**
+     * Find which route matches a URL
+     *
+     * Tests each route in order to find the first match.
+     *
+     * @param string $url URL to test
+     * @return int|null Index of matching route, or null if no match
+     */
+    private function findMatchingRoute(string $url): ?int
+    {
+        // Test each route in order (mimicking Mapper's behavior)
+        foreach ($this->mapper->matchList as $index => $route) {
+            if ($route->static) {
+                continue;
+            }
+
+            // Test if this route matches the URL
+            $match = $route->match($url, [
+                'environ' => $this->mapper->environ,
+                'subDomains' => $this->mapper->subDomains,
+                'subDomainsIgnore' => $this->mapper->subDomainsIgnore,
+                'domainMatch' => $this->mapper->domainMatch ?? ''
+            ]);
+
+            if ($match !== null) {
+                return $index;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/FluentRouteBuilder.php
+++ b/src/FluentRouteBuilder.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Horde Routes package
+ *
+ * This package is heavily inspired by the Python "Routes" library
+ * by Ben Bangert (http://routes.groovie.org).  This PHP version
+ * includes several enhancements and modifications:
+ *  - Fluent RouteBuilder API for strongly-typed route definitions
+ *  - Secondary/legacy route support
+ *  - Integration with PSR-7/PSR-15 middleware stacks
+ *
+ * @author  Maintainable Software, LLC. (http://www.maintainable.com)
+ * @author  Ralf Lang <lang@b1-systems.de>
+ * @license http://www.horde.org/licenses/bsd BSD
+ * @package Routes
+ */
+
+declare(strict_types=1);
+
+namespace Horde\Routes;
+
+/**
+ * Fluent wrapper for RouteBuilder that enables ->add() chaining
+ *
+ * FluentRouteBuilder wraps a RouteBuilder instance and provides method
+ * proxying via __call() to forward all RouteBuilder methods. It adds a
+ * single method ->add() that builds the route, adds it to the Mapper,
+ * and returns the Mapper for further chaining.
+ *
+ * This enables clean fluent API:
+ * <code>
+ * $mapper->route('users/:id')
+ *        ->controller('User')
+ *        ->action('show')
+ *        ->add()
+ *        ->route('users')
+ *        ->controller('User')
+ *        ->action('index')
+ *        ->add();
+ * </code>
+ *
+ * @package Routes
+ */
+class FluentRouteBuilder
+{
+    /**
+     * The underlying RouteBuilder instance
+     */
+    private RouteBuilder $builder;
+
+    /**
+     * The Mapper instance to add routes to
+     */
+    private Mapper $mapper;
+
+    /**
+     * Create a new fluent route builder
+     *
+     * @param Mapper $mapper Mapper instance
+     * @param string $path Route path pattern
+     */
+    public function __construct(Mapper $mapper, string $path)
+    {
+        $this->mapper = $mapper;
+        $this->builder = new RouteBuilder($path);
+    }
+
+    /**
+     * Get the underlying RouteBuilder instance
+     *
+     * @return RouteBuilder The builder instance
+     */
+    public function getBuilder(): RouteBuilder
+    {
+        return $this->builder;
+    }
+
+    /**
+     * Build and add the route to the mapper, returning the mapper
+     *
+     * This method completes the fluent chain by building the route,
+     * adding it to the mapper, and returning the mapper for further
+     * route definitions.
+     *
+     * @return Mapper The mapper instance for chaining
+     */
+    public function add(): Mapper
+    {
+        $this->mapper->addRoute($this->builder);
+        return $this->mapper;
+    }
+
+    /**
+     * Proxy all other method calls to the underlying RouteBuilder
+     *
+     * All RouteBuilder methods (name, controller, action, requires, etc.)
+     * are forwarded to the builder. The builder returns itself, which is
+     * then wrapped back into this FluentRouteBuilder for continued chaining.
+     *
+     * @param string $method Method name
+     * @param array<mixed> $args Method arguments
+     * @return self This fluent builder for chaining
+     * @throws \Error If method doesn't exist on RouteBuilder
+     */
+    public function __call(string $method, array $args): self
+    {
+        $result = $this->builder->$method(...$args);
+
+        // If RouteBuilder method returned $this (fluent chaining),
+        // return this FluentRouteBuilder instead
+        if ($result === $this->builder) {
+            return $this;
+        }
+
+        // Otherwise return the actual result (shouldn't happen for setter methods)
+        return $result;
+    }
+}

--- a/src/Mapper.php
+++ b/src/Mapper.php
@@ -319,6 +319,209 @@ class Mapper
     }
 
     /**
+     * Connect a secondary/legacy route that matches but doesn't generate
+     *
+     * Secondary routes are useful for supporting alternative URLs (e.g., during
+     * migration from legacy URL schemes) without affecting canonical URL generation.
+     *
+     * Usage:
+     *   // Primary route (used for generation)
+     *   $m->connect('api/users/:id', ['middleware' => ['ApiAuth']]);
+     *
+     *   // Secondary routes (match only, not generated) - e.g., legacy URLs
+     *   $m->connectSecondary('user/:id', ['middleware' => ['ApiAuth']]);
+     *   $m->connectSecondary('profile/:id', ['middleware' => ['ApiAuth']]);
+     *
+     * Note: Designed for modern PSR-7/PSR-15 applications using Horde\Http\Server.
+     * For legacy Horde_Controller applications, consider migrating to PSR-15.
+     * See: horde-development/libraries/controller/controller-deprecation-notice.md
+     *
+     * @param  mixed  $first   First argument (route name or path)
+     * @param  mixed  $second  Second argument (path or kargs)
+     * @param  mixed  $third   Third argument (kargs if named route)
+     * @return void
+     */
+    public function connectSecondary($first, $second = null, $third = null): void
+    {
+        // Parse arguments same as connect()
+        if ($third !== null) {
+            // 3 args: connect('route_name', '/path', array('kargs'=>'here'))
+            $routeName = $first;
+            $routePath = $second;
+            $kargs = $third;
+        } elseif ($second !== null) {
+            if (is_array($second)) {
+                // 2 args: connect('/path', array('kargs'=>'here'))
+                $routeName = null;
+                $routePath = $first;
+                $kargs = $second;
+            } else {
+                // 2 args: connect('route_name', '/path')
+                $routeName = $first;
+                $routePath = $second;
+                $kargs = [];
+            }
+        } else {
+            // 1 arg: connect('/path')
+            $routeName = null;
+            $routePath = $first;
+            $kargs = [];
+        }
+
+        // Mark as secondary
+        $kargs['_secondary'] = true;
+
+        // Use existing connect logic
+        if ($routeName === null) {
+            $this->connect($routePath, $kargs);
+        } else {
+            $this->connect($routeName, $routePath, $kargs);
+        }
+    }
+
+    /**
+     * Get list of all routes with metadata
+     *
+     * Returns array of route information including path, name, type (primary/secondary),
+     * static flag, defaults, and conditions. Useful for debugging and route documentation.
+     *
+     * Example return:
+     *   [
+     *     ['path' => 'api/users/:id', 'name' => 'api_user', 'type' => 'primary', ...],
+     *     ['path' => 'user/:id', 'name' => null, 'type' => 'secondary', ...],
+     *   ]
+     *
+     * @return array Array of route metadata arrays
+     */
+    public function getRouteList(): array
+    {
+        $routes = [];
+
+        foreach ($this->matchList as $route) {
+            // Find the route name if it exists
+            $name = null;
+            foreach ($this->routeNames as $routeName => $routeObj) {
+                if ($routeObj === $route) {
+                    $name = $routeName;
+                    break;
+                }
+            }
+
+            $routes[] = [
+                'path' => $route->routePath,
+                'name' => $name,
+                'type' => $route->secondary ? 'secondary' : 'primary',
+                'static' => $route->static,
+                'defaults' => $route->defaults,
+                'conditions' => $route->conditions,
+            ];
+        }
+
+        return $routes;
+    }
+
+    /**
+     * Add a route using RouteBuilder or Route object
+     *
+     * This method accepts either a RouteBuilder instance (which will be built)
+     * or a Route object directly. It provides integration between the fluent
+     * builder API and the traditional array-based Mapper.
+     *
+     * Example with RouteBuilder:
+     * <code>
+     * $builder = new RouteBuilder('users/:id');
+     * $builder->controller('User')->action('show')->get();
+     * $mapper->addRoute($builder);
+     * </code>
+     *
+     * Example with Route:
+     * <code>
+     * $route = new Route('users/:id', null, ['controller' => 'User']);
+     * $mapper->addRoute($route);
+     * </code>
+     *
+     * Designed for modern PSR-7/PSR-15 applications using the Rampage middleware
+     * framework. Legacy Horde_Controller applications may have limited support.
+     *
+     * @param RouteBuilder|Route $routeOrBuilder RouteBuilder or Route object to add
+     * @return void
+     */
+    public function addRoute(RouteBuilder|Route $routeOrBuilder): void
+    {
+        // If it's a RouteBuilder, build it first
+        if ($routeOrBuilder instanceof RouteBuilder) {
+            $route = $routeOrBuilder->build();
+        } else {
+            $route = $routeOrBuilder;
+        }
+
+        // Apply encoding settings
+        if ($this->encoding != 'utf-8' || $this->decodeErrors != 'ignore') {
+            $route->encoding = $this->encoding;
+            $route->decodeErrors = $this->decodeErrors;
+        }
+
+        // Add to match list
+        $this->matchList[] = $route;
+
+        // If route has a name, add to named routes dictionary
+        $routeName = $route->routeName;
+        if ($routeName !== null) {
+            $this->routeNames[$routeName] = $route;
+        }
+
+        // If not static, add to maxKeys for generation
+        if (!$route->static) {
+            $exists = false;
+            foreach ($this->maxKeys as $key => $value) {
+                if (unserialize($key) == $route->maxKeys) {
+                    $this->maxKeys[$key][] = $route;
+                    $exists = true;
+                    break;
+                }
+            }
+
+            if (!$exists) {
+                $this->maxKeys[serialize($route->maxKeys)] = [$route];
+            }
+        }
+
+        // Invalidate generation cache
+        $this->createdGens = false;
+    }
+
+    /**
+     * Start a fluent route definition
+     *
+     * Returns a FluentRouteBuilder that proxies to RouteBuilder and adds
+     * an ->add() method for chaining multiple route definitions.
+     *
+     * Example:
+     * <code>
+     * $mapper->route('users/:id')
+     *        ->controller('User')
+     *        ->action('show')
+     *        ->requires('id', '\d+')
+     *        ->get()
+     *        ->add()
+     *        ->route('users')
+     *        ->controller('User')
+     *        ->action('index')
+     *        ->add();
+     * </code>
+     *
+     * Designed for modern PSR-7/PSR-15 applications using the Rampage middleware
+     * framework. Legacy Horde_Controller applications may have limited support.
+     *
+     * @param string $path Route path pattern
+     * @return FluentRouteBuilder Fluent builder wrapper
+     */
+    public function route(string $path): FluentRouteBuilder
+    {
+        return new FluentRouteBuilder($this, $path);
+    }
+
+    /**
      * Set an optional Horde_Cache object for the created rules.
      *
      * @param Horde_Cache $cache Cache object
@@ -354,7 +557,7 @@ class Mapper
 
         // Assemble all the hardcoded/defaulted actions/controllers used
         foreach ($this->matchList as $route) {
-            if ($route->static) {
+            if ($route->static || $route->secondary) {
                 continue;
             }
             if (isset($route->defaults['controller'])) {
@@ -373,7 +576,7 @@ class Mapper
         // Otherwise we add it to every hardcode since it can be changed.
         $gendict = [];  // Our generated two-deep hash
         foreach ($this->matchList as $route) {
-            if ($route->static) {
+            if ($route->static || $route->secondary) {
                 continue;
             }
             $clist = $controllerList;

--- a/src/Matcher.php
+++ b/src/Matcher.php
@@ -76,7 +76,23 @@ class Matcher
     public function getMatchDict()
     {
         if ($this->match_dict === null) {
-            $path = $this->request->getPath();
+            // Auto-populate environ from request
+            if (method_exists($this->request, 'getMethod')) {
+                $this->mapper->environ = ['REQUEST_METHOD' => $this->request->getMethod()];
+            }
+
+            // Extract path from request - handle both PSR-7 and Horde_Controller_Request
+            if (method_exists($this->request, 'getPath')) {
+                // Horde_Controller_Request or our TestRequest
+                $path = $this->request->getPath();
+            } elseif (method_exists($this->request, 'getUri')) {
+                // PSR-7 ServerRequestInterface
+                $path = $this->request->getUri()->getPath();
+            } else {
+                throw new \RuntimeException('Request must implement getPath() or getUri()');
+            }
+
+            // Strip query string
             if (($pos = strpos($path, '?')) !== false) {
                 $path = substr($path, 0, $pos);
             }

--- a/src/Route.php
+++ b/src/Route.php
@@ -67,6 +67,16 @@ class Route
     public bool $explicit;
 
     /**
+     * Optional route name for named routes
+     *
+     * Named routes can be referenced by name during URL generation.
+     * This property is set by RouteBuilder when using the fluent API.
+     *
+     * @var string|null
+     */
+    public ?string $routeName = null;
+
+    /**
      * Default keyword arguments for this route
      * @var array
      */
@@ -166,6 +176,21 @@ class Route
     public $stack;
 
     /**
+     * Is this a secondary/legacy route that matches but doesn't generate?
+     *
+     * Secondary routes are useful for supporting alternative URLs (e.g., legacy
+     * URLs during migration) without affecting URL generation. They participate
+     * in matching but are excluded from the generation dictionary.
+     *
+     * This feature is designed for modern PSR-7/PSR-15 applications using the
+     * Rampage middleware framework (Horde\Http\Server). Legacy Horde_Controller
+     * applications may have limited support.
+     *
+     * @var bool
+     */
+    public bool $secondary = false;
+
+    /**
      *  Initialize a route, with a given routepath for matching/generation
      *
      *  The set of keyword args will be used as defaults.
@@ -196,6 +221,10 @@ class Route
             $this->stack = $kargs['stack'];
             unset($kargs['stack']);
         }
+
+        // Secondary routes match but don't generate URLs
+        $this->secondary = $kargs['_secondary'] ?? false;
+        unset($kargs['_secondary']);
 
         $this->filter = $kargs['_filter'] ?? null;
         unset($kargs['_filter']);

--- a/src/RouteBuilder.php
+++ b/src/RouteBuilder.php
@@ -1,0 +1,447 @@
+<?php
+/**
+ * Horde Routes package
+ *
+ * This package is heavily inspired by the Python "Routes" library
+ * by Ben Bangert (http://routes.groovie.org).  This PHP version
+ * includes several enhancements and modifications:
+ *  - Fluent RouteBuilder API for strongly-typed route definitions
+ *  - Secondary/legacy route support
+ *  - Integration with PSR-7/PSR-15 middleware stacks
+ *
+ * @author  Maintainable Software, LLC. (http://www.maintainable.com)
+ * @author  Ralf Lang <lang@b1-systems.de>
+ * @license http://www.horde.org/licenses/bsd BSD
+ * @package Routes
+ */
+
+declare(strict_types=1);
+
+namespace Horde\Routes;
+
+/**
+ * Fluent route builder for creating routes with IDE-friendly autocomplete
+ *
+ * RouteBuilder provides a strongly-typed, chainable API for building routes
+ * as an alternative to the array-based connect() method. All setter methods
+ * return $this for fluent chaining.
+ *
+ * Basic usage:
+ * <code>
+ * $builder = new RouteBuilder('users/:id');
+ * $builder->name('user_show')
+ *         ->controller('User')
+ *         ->action('show')
+ *         ->requires('id', '\d+')
+ *         ->get()
+ *         ->middleware(['Auth']);
+ *
+ * $route = $builder->build();  // Creates Route object
+ * </code>
+ *
+ * Integration with Mapper:
+ * <code>
+ * $mapper->addRoute($builder);  // Adds RouteBuilder or Route
+ * </code>
+ *
+ * @package Routes
+ */
+class RouteBuilder
+{
+    /**
+     * Route path pattern
+     */
+    private string $path;
+
+    /**
+     * Optional route name for named routes
+     */
+    private ?string $name = null;
+
+    /**
+     * Default values (controller, action, etc.)
+     *
+     * @var array<string, mixed>
+     */
+    private array $defaults = [];
+
+    /**
+     * Requirements (regex patterns for route variables)
+     *
+     * @var array<string, string>
+     */
+    private array $requirements = [];
+
+    /**
+     * Conditions (method, subdomain, function)
+     *
+     * @var array<string, mixed>
+     */
+    private array $conditions = [];
+
+    /**
+     * Middleware stack
+     *
+     * @var array<string>
+     */
+    private array $stack = [];
+
+    /**
+     * Flags (_secondary, _absolute, _static, _filter)
+     *
+     * @var array<string, bool>
+     */
+    private array $flags = [];
+
+    /**
+     * Create a new route builder
+     *
+     * @param string $path Route path pattern (e.g., 'users/:id')
+     */
+    public function __construct(string $path)
+    {
+        $this->path = $path;
+    }
+
+    /**
+     * Set route name for named routes
+     *
+     * Named routes can be referenced by name during URL generation.
+     *
+     * @param string $name Route name
+     * @return self
+     */
+    public function name(string $name): self
+    {
+        $this->name = $name;
+        return $this;
+    }
+
+    /**
+     * Get the route name
+     *
+     * @return string|null Route name or null if not named
+     */
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    /**
+     * Set controller default
+     *
+     * @param string $controller Controller name or class
+     * @return self
+     */
+    public function controller(string $controller): self
+    {
+        $this->defaults['controller'] = $controller;
+        return $this;
+    }
+
+    /**
+     * Set action default
+     *
+     * @param string $action Action name
+     * @return self
+     */
+    public function action(string $action): self
+    {
+        $this->defaults['action'] = $action;
+        return $this;
+    }
+
+    /**
+     * Set arbitrary default value
+     *
+     * @param string $key Default key
+     * @param mixed $value Default value
+     * @return self
+     */
+    public function defaults(string $key, mixed $value): self
+    {
+        $this->defaults[$key] = $value;
+        return $this;
+    }
+
+    /**
+     * Set multiple defaults at once
+     *
+     * Merges with existing defaults.
+     *
+     * @param array<string, mixed> $defaults Associative array of defaults
+     * @return self
+     */
+    public function withDefaults(array $defaults): self
+    {
+        $this->defaults = array_merge($this->defaults, $defaults);
+        return $this;
+    }
+
+    /**
+     * Add requirement (regex pattern) for route variable
+     *
+     * @param string $key Variable name
+     * @param string $pattern Regex pattern (without delimiters)
+     * @return self
+     */
+    public function requires(string $key, string $pattern): self
+    {
+        $this->requirements[$key] = $pattern;
+        return $this;
+    }
+
+    /**
+     * Add multiple requirements at once
+     *
+     * @param array<string, string> $requirements Associative array of variable => pattern
+     * @return self
+     */
+    public function withRequirements(array $requirements): self
+    {
+        $this->requirements = array_merge($this->requirements, $requirements);
+        return $this;
+    }
+
+    /**
+     * Restrict route to GET requests
+     *
+     * @return self
+     */
+    public function get(): self
+    {
+        $this->conditions['method'] = ['GET'];
+        return $this;
+    }
+
+    /**
+     * Restrict route to POST requests
+     *
+     * @return self
+     */
+    public function post(): self
+    {
+        $this->conditions['method'] = ['POST'];
+        return $this;
+    }
+
+    /**
+     * Restrict route to PUT requests
+     *
+     * @return self
+     */
+    public function put(): self
+    {
+        $this->conditions['method'] = ['PUT'];
+        return $this;
+    }
+
+    /**
+     * Restrict route to DELETE requests
+     *
+     * @return self
+     */
+    public function delete(): self
+    {
+        $this->conditions['method'] = ['DELETE'];
+        return $this;
+    }
+
+    /**
+     * Restrict route to PATCH requests
+     *
+     * @return self
+     */
+    public function patch(): self
+    {
+        $this->conditions['method'] = ['PATCH'];
+        return $this;
+    }
+
+    /**
+     * Restrict route to specific HTTP methods
+     *
+     * @param array<string> $methods Array of HTTP method names (e.g., ['GET', 'HEAD'])
+     * @return self
+     */
+    public function methods(array $methods): self
+    {
+        $this->conditions['method'] = $methods;
+        return $this;
+    }
+
+    /**
+     * Restrict route to specific subdomain
+     *
+     * @param string $subdomain Subdomain name
+     * @return self
+     */
+    public function subdomain(string $subdomain): self
+    {
+        $this->conditions['subdomain'] = $subdomain;
+        return $this;
+    }
+
+    /**
+     * Add custom condition function
+     *
+     * Function receives environ array and returns bool.
+     *
+     * @param callable $callable Condition function
+     * @return self
+     */
+    public function where(callable $callable): self
+    {
+        $this->conditions['function'] = $callable;
+        return $this;
+    }
+
+    /**
+     * Set middleware stack for this route
+     *
+     * Middleware is executed in order for PSR-15 applications using
+     * the Rampage framework. Not supported in legacy Horde_Controller.
+     *
+     * @param array<string> $middleware Array of middleware class names
+     * @return self
+     */
+    public function middleware(array $middleware): self
+    {
+        $this->stack = $middleware;
+        return $this;
+    }
+
+    /**
+     * Explicitly set empty middleware stack
+     *
+     * Useful for public routes that should skip default middleware.
+     *
+     * @return self
+     */
+    public function noMiddleware(): self
+    {
+        $this->stack = [];
+        return $this;
+    }
+
+    /**
+     * Mark route as secondary/legacy (matches but doesn't generate)
+     *
+     * Secondary routes are useful for supporting alternative URLs (e.g., legacy
+     * URLs during migration) without affecting URL generation. They participate
+     * in matching but are excluded from the generation dictionary.
+     *
+     * Designed for modern PSR-7/PSR-15 applications using the Rampage middleware
+     * framework. Legacy Horde_Controller applications may have limited support.
+     *
+     * @param bool $secondary True to mark as secondary, false to unmark
+     * @return self
+     */
+    public function secondary(bool $secondary = true): self
+    {
+        if ($secondary) {
+            $this->flags['_secondary'] = true;
+        } else {
+            unset($this->flags['_secondary']);
+        }
+        return $this;
+    }
+
+    /**
+     * Mark route as absolute
+     *
+     * @param bool $absolute True to mark as absolute
+     * @return self
+     */
+    public function absolute(bool $absolute = true): self
+    {
+        if ($absolute) {
+            $this->flags['_absolute'] = true;
+        } else {
+            unset($this->flags['_absolute']);
+        }
+        return $this;
+    }
+
+    /**
+     * Mark route as static
+     *
+     * @param bool $static True to mark as static
+     * @return self
+     */
+    public function static(bool $static = true): self
+    {
+        if ($static) {
+            $this->flags['_static'] = true;
+        } else {
+            unset($this->flags['_static']);
+        }
+        return $this;
+    }
+
+    /**
+     * Mark route as filter
+     *
+     * @param bool $filter True to mark as filter
+     * @return self
+     */
+    public function filter(bool $filter = true): self
+    {
+        if ($filter) {
+            $this->flags['_filter'] = true;
+        } else {
+            unset($this->flags['_filter']);
+        }
+        return $this;
+    }
+
+    /**
+     * Convert builder configuration to array format
+     *
+     * Returns array suitable for passing to Mapper->connect().
+     *
+     * @return array<string, mixed> Route configuration
+     */
+    public function toArray(): array
+    {
+        $config = $this->defaults;
+
+        if (!empty($this->requirements)) {
+            $config['requirements'] = $this->requirements;
+        }
+
+        if (!empty($this->conditions)) {
+            $config['conditions'] = $this->conditions;
+        }
+
+        // Always include stack, even if empty (explicitly set via noMiddleware())
+        $config['stack'] = $this->stack;
+
+        // Merge flags
+        $config = array_merge($config, $this->flags);
+
+        return $config;
+    }
+
+    /**
+     * Build Route object from builder configuration
+     *
+     * Creates a Route object from the builder's configuration. Note that the
+     * route name is not passed to the Route constructor - it's stored separately
+     * and registered by Mapper when the route is added.
+     *
+     * @return Route Built route object
+     */
+    public function build(): Route
+    {
+        $config = $this->toArray();
+        $route = new Route($this->path, $config);
+
+        // Store the route name on the Route object for Mapper to register
+        if ($this->name !== null) {
+            $route->routeName = $this->name;
+        }
+
+        return $route;
+    }
+}

--- a/test/Analysis/RouteAnalysisReportTest.php
+++ b/test/Analysis/RouteAnalysisReportTest.php
@@ -1,0 +1,213 @@
+<?php
+/**
+ * Horde Routes package
+ *
+ * @author  Ralf Lang <lang@b1-systems.de>
+ * @license http://www.horde.org/licenses/bsd BSD
+ * @package Routes
+ */
+
+namespace Horde\Routes\Test\Analysis;
+
+use PHPUnit\Framework\TestCase;
+use Horde\Routes\Analysis\RouteAnalysisReport;
+
+/**
+ * Tests for RouteAnalysisReport formatting
+ *
+ * Tests the various output formats (text, JSON) for route analysis reports.
+ *
+ * @package Routes
+ */
+class RouteAnalysisReportTest extends TestCase
+{
+    // ============================================================
+    // Format Tests
+    // ============================================================
+
+    /**
+     * Test formatting empty warnings array as text
+     */
+    public function testFormatTextEmpty(): void
+    {
+        $warnings = [];
+
+        $report = new RouteAnalysisReport($warnings);
+        $output = $report->formatText();
+
+        $this->assertIsString($output);
+        $this->assertNotEmpty($output);
+
+        // Should indicate no issues found
+        $this->assertStringContainsString('No issues', $output);
+    }
+
+    /**
+     * Test formatting shadowed route warning as text
+     */
+    public function testFormatTextShadowedRoute(): void
+    {
+        $warnings = [
+            [
+                'type' => 'shadowed',
+                'message' => 'Route is unreachable due to earlier route',
+                'shadowed_route' => 'users/search',
+                'shadowing_route' => 'users/:action',
+                'test_url' => '/users/search',
+                'matched_route' => 'users/:action',
+                'severity' => 'error'
+            ]
+        ];
+
+        $report = new RouteAnalysisReport($warnings);
+        $output = $report->formatText();
+
+        $this->assertIsString($output);
+
+        // Should contain key information
+        $this->assertStringContainsString('shadowed', $output);
+        $this->assertStringContainsString('users/search', $output);
+        $this->assertStringContainsString('users/:action', $output);
+
+        // Should indicate severity
+        $this->assertStringContainsString('error', $output);
+    }
+
+    /**
+     * Test formatting invalid requirement warning as text
+     */
+    public function testFormatTextInvalidRequirement(): void
+    {
+        $warnings = [
+            [
+                'type' => 'invalid_requirement',
+                'message' => 'Invalid regex pattern in requirement',
+                'route' => 'posts/:id',
+                'parameter' => 'id',
+                'pattern' => '[0-9',
+                'error' => 'Compilation failed: missing terminating ]',
+                'severity' => 'error'
+            ]
+        ];
+
+        $report = new RouteAnalysisReport($warnings);
+        $output = $report->formatText();
+
+        $this->assertIsString($output);
+
+        // Should contain error details
+        $this->assertStringContainsString('invalid', $output);
+        $this->assertStringContainsString('posts/:id', $output);
+        $this->assertStringContainsString('id', $output);
+        $this->assertStringContainsString('[0-9', $output);
+    }
+
+    /**
+     * Test formatting empty warnings array as JSON
+     */
+    public function testFormatJsonEmpty(): void
+    {
+        $warnings = [];
+
+        $report = new RouteAnalysisReport($warnings);
+        $output = $report->formatJson();
+
+        $this->assertIsString($output);
+
+        // Should be valid JSON
+        $decoded = json_decode($output, true);
+        $this->assertIsArray($decoded);
+
+        // Should have expected structure
+        $this->assertArrayHasKey('warnings', $decoded);
+        $this->assertArrayHasKey('summary', $decoded);
+
+        // Warnings should be empty
+        $this->assertEmpty($decoded['warnings']);
+
+        // Summary should show 0 issues
+        $this->assertEquals(0, $decoded['summary']['total']);
+    }
+
+    /**
+     * Test formatting warnings as JSON
+     */
+    public function testFormatJsonWithWarnings(): void
+    {
+        $warnings = [
+            [
+                'type' => 'shadowed',
+                'message' => 'Route is unreachable',
+                'shadowed_route' => 'users/search',
+                'shadowing_route' => 'users/:action',
+                'test_url' => '/users/search',
+                'matched_route' => 'users/:action',
+                'severity' => 'error'
+            ],
+            [
+                'type' => 'duplicate',
+                'message' => 'Duplicate route definition',
+                'route' => 'posts/:id',
+                'severity' => 'warning'
+            ]
+        ];
+
+        $report = new RouteAnalysisReport($warnings);
+        $output = $report->formatJson();
+
+        $this->assertIsString($output);
+
+        // Should be valid JSON
+        $decoded = json_decode($output, true);
+        $this->assertIsArray($decoded);
+
+        // Should have all warnings
+        $this->assertCount(2, $decoded['warnings']);
+
+        // First warning should have expected fields
+        $first = $decoded['warnings'][0];
+        $this->assertEquals('shadowed', $first['type']);
+        $this->assertEquals('users/search', $first['shadowed_route']);
+        $this->assertEquals('error', $first['severity']);
+
+        // Summary should count by severity
+        $this->assertEquals(2, $decoded['summary']['total']);
+        $this->assertArrayHasKey('by_severity', $decoded['summary']);
+    }
+
+    /**
+     * Test warning serialization excludes Route objects
+     *
+     * Route objects should not be serialized to JSON (circular refs, too large)
+     * Only use route paths and relevant string data.
+     */
+    public function testSerializeWarning(): void
+    {
+        $warnings = [
+            [
+                'type' => 'shadowed',
+                'message' => 'Route is unreachable',
+                'shadowed_route' => 'users/search',
+                'shadowing_route' => 'users/:action',
+                'severity' => 'error',
+                // These should be excluded from serialization
+                'route_object' => new \stdClass(),
+                'internal_data' => ['debug' => 'info']
+            ]
+        ];
+
+        $report = new RouteAnalysisReport($warnings);
+        $output = $report->formatJson();
+
+        $decoded = json_decode($output, true);
+
+        // Should not contain internal/debug fields
+        $first = $decoded['warnings'][0];
+        $this->assertArrayNotHasKey('route_object', $first);
+        $this->assertArrayNotHasKey('internal_data', $first);
+
+        // Should contain public fields
+        $this->assertArrayHasKey('type', $first);
+        $this->assertArrayHasKey('message', $first);
+    }
+}

--- a/test/Analysis/RouteAnalyzerIntegrationTest.php
+++ b/test/Analysis/RouteAnalyzerIntegrationTest.php
@@ -1,0 +1,301 @@
+<?php
+/**
+ * Horde Routes package
+ *
+ * @author  Ralf Lang <lang@b1-systems.de>
+ * @license http://www.horde.org/licenses/bsd BSD
+ * @package Routes
+ */
+
+namespace Horde\Routes\Test\Analysis;
+
+use PHPUnit\Framework\TestCase;
+use Horde\Routes\Mapper;
+use Horde\Routes\Analysis\RouteAnalyzer;
+use Horde\Routes\Analysis\RouteAnalysisReport;
+
+/**
+ * Integration tests for RouteAnalyzer with real-world scenarios
+ *
+ * Tests complex routing patterns and performance with larger route sets.
+ *
+ * @package Routes
+ * @group integration
+ */
+class RouteAnalyzerIntegrationTest extends TestCase
+{
+    // ============================================================
+    // Real-World Scenarios
+    // ============================================================
+
+    /**
+     * Test classic controller/action shadowing issue
+     *
+     * This is the most common routing mistake:
+     * Route with :action before specific action routes
+     */
+    public function testClassicControllerActionShadowing(): void
+    {
+        $m = new Mapper();
+
+        // Anti-pattern: catch-all with :action
+        $m->connect('users/:action/:id', ['controller' => 'User']);
+
+        // These specific routes are now unreachable
+        $m->connect('users/search', ['controller' => 'Search', 'action' => 'users']);
+        $m->connect('users/export', ['controller' => 'Export', 'action' => 'users']);
+
+        $analyzer = new RouteAnalyzer($m);
+        $warnings = $analyzer->analyze();
+
+        // Should detect both shadowed routes
+        $this->assertGreaterThanOrEqual(2, count($warnings));
+
+        $shadowedPaths = [];
+        foreach ($warnings as $warning) {
+            if ($warning['type'] === 'shadowed') {
+                $shadowedPaths[] = $warning['shadowed_route'];
+            }
+        }
+
+        $this->assertContains('users/search', implode(',', $shadowedPaths));
+        $this->assertContains('users/export', implode(',', $shadowedPaths));
+    }
+
+    /**
+     * Test RESTful resource shadowing
+     *
+     * GET /posts/:id vs GET /posts/new - "new" gets interpreted as :id
+     */
+    public function testRESTfulResourceShadowing(): void
+    {
+        $m = new Mapper();
+
+        // RESTful routes - common pattern
+        $m->connect('posts/:id', [
+            'controller' => 'Post',
+            'action' => 'show',
+            'conditions' => ['method' => ['GET']]
+        ]);
+
+        // Form to create new post - shadowed by :id route
+        $m->connect('posts/new', [
+            'controller' => 'Post',
+            'action' => 'new',
+            'conditions' => ['method' => ['GET']]
+        ]);
+
+        $analyzer = new RouteAnalyzer($m);
+        $warnings = $analyzer->analyze();
+
+        // Should detect posts/new being shadowed
+        $this->assertNotEmpty($warnings);
+
+        $shadowedNew = false;
+        foreach ($warnings as $warning) {
+            if ($warning['type'] === 'shadowed' &&
+                str_contains($warning['shadowed_route'], 'posts/new')) {
+                $shadowedNew = true;
+                break;
+            }
+        }
+
+        $this->assertTrue($shadowedNew, 'Should detect posts/new shadowed by posts/:id');
+    }
+
+    /**
+     * Test API versioning does NOT cause shadowing
+     *
+     * v1/users/:id and v2/users/:id are different routes
+     */
+    public function testApiVersioningShadowing(): void
+    {
+        $m = new Mapper();
+
+        // Different API versions - should not shadow
+        $m->connect('api/v1/users/:id', ['controller' => 'Api\\V1\\User', 'action' => 'show']);
+        $m->connect('api/v2/users/:id', ['controller' => 'Api\\V2\\User', 'action' => 'show']);
+
+        $analyzer = new RouteAnalyzer($m);
+        $warnings = $analyzer->analyze();
+
+        // Should NOT detect shadowing (different paths)
+        $this->assertEmpty($warnings, 'API versioning routes should not shadow each other');
+    }
+
+    /**
+     * Test analyzer with large route set (100+ routes)
+     *
+     * Ensures performance is acceptable and finds issues in complex apps
+     */
+    public function testLargeRouteSet(): void
+    {
+        $m = new Mapper();
+
+        // Add 100+ routes simulating a real application
+        // Public routes
+        $m->connect('', ['controller' => 'Home', 'action' => 'index']);
+        $m->connect('about', ['controller' => 'Pages', 'action' => 'about']);
+        $m->connect('contact', ['controller' => 'Pages', 'action' => 'contact']);
+
+        // User routes (30 routes)
+        for ($i = 0; $i < 15; $i++) {
+            $m->connect("section{$i}/users/:id", ['controller' => "Section{$i}User", 'action' => 'show']);
+            $m->connect("section{$i}/users", ['controller' => "Section{$i}User", 'action' => 'index']);
+        }
+
+        // API routes (50 routes)
+        $resources = ['users', 'posts', 'comments', 'tags', 'categories', 'photos', 'videos', 'files', 'messages', 'notifications'];
+        $actions = ['index', 'show', 'create', 'update', 'delete'];
+        foreach ($resources as $resource) {
+            foreach ($actions as $action) {
+                if ($action === 'index' || $action === 'create') {
+                    $m->connect("api/{$resource}", [
+                        'controller' => "Api\\" . ucfirst($resource),
+                        'action' => $action,
+                        'conditions' => ['method' => [$action === 'index' ? 'GET' : 'POST']]
+                    ]);
+                } else {
+                    $m->connect("api/{$resource}/:id", [
+                        'controller' => "Api\\" . ucfirst($resource),
+                        'action' => $action,
+                        'conditions' => ['method' => [
+                            $action === 'show' ? 'GET' :
+                            ($action === 'update' ? 'PUT' : 'DELETE')
+                        ]]
+                    ]);
+                }
+            }
+        }
+
+        // Admin routes (20 routes)
+        for ($i = 0; $i < 20; $i++) {
+            $m->connect("admin/module{$i}/:action", ['controller' => "Admin\\Module{$i}"]);
+        }
+
+        // Add problematic route that shadows
+        $m->connect('api/:resource/:id', ['controller' => 'Api\\Generic']);
+
+        $this->assertGreaterThan(100, count($m->matchList), 'Should have 100+ routes');
+
+        $analyzer = new RouteAnalyzer($m);
+
+        $startTime = microtime(true);
+        $warnings = $analyzer->analyze();
+        $duration = microtime(true) - $startTime;
+
+        // Should complete in reasonable time
+        $this->assertLessThan(5.0, $duration, 'Analysis should complete in under 5 seconds for 100+ routes');
+
+        // Should find the problematic api/:resource/:id route
+        $this->assertNotEmpty($warnings, 'Should detect shadowing in large route set');
+    }
+
+    // ============================================================
+    // Report Format Tests
+    // ============================================================
+
+    /**
+     * Test text report format
+     *
+     * Human-readable output with sections and formatting
+     */
+    public function testTextReportFormat(): void
+    {
+        $m = new Mapper();
+
+        // Create some issues
+        $m->connect('users/:action', ['controller' => 'User']);
+        $m->connect('users/search', ['controller' => 'Search', 'action' => 'users']);
+
+        $analyzer = new RouteAnalyzer($m);
+        $warnings = $analyzer->analyze();
+
+        $report = new RouteAnalysisReport($warnings);
+        $textOutput = $report->formatText();
+
+        $this->assertIsString($textOutput);
+        $this->assertNotEmpty($textOutput);
+
+        // Should contain sections
+        $this->assertStringContainsString('Route Analysis', $textOutput);
+        $this->assertStringContainsString('Shadowed', $textOutput);
+
+        // Should contain route information
+        $this->assertStringContainsString('users/search', $textOutput);
+        $this->assertStringContainsString('users/:action', $textOutput);
+    }
+
+    /**
+     * Test JSON report format
+     *
+     * Machine-readable output for tooling integration
+     */
+    public function testJsonReportFormat(): void
+    {
+        $m = new Mapper();
+
+        // Create some issues
+        $m->connect('posts/:id', ['controller' => 'Post', 'action' => 'show']);
+        $m->connect('posts/recent', ['controller' => 'Post', 'action' => 'recent']);
+
+        $analyzer = new RouteAnalyzer($m);
+        $warnings = $analyzer->analyze();
+
+        $report = new RouteAnalysisReport($warnings);
+        $jsonOutput = $report->formatJson();
+
+        $this->assertIsString($jsonOutput);
+
+        // Should be valid JSON
+        $decoded = json_decode($jsonOutput, true);
+        $this->assertIsArray($decoded);
+
+        // Should have expected structure
+        $this->assertArrayHasKey('warnings', $decoded);
+        $this->assertArrayHasKey('summary', $decoded);
+
+        // Warnings should have required fields
+        if (!empty($decoded['warnings'])) {
+            $firstWarning = $decoded['warnings'][0];
+            $this->assertArrayHasKey('type', $firstWarning);
+            $this->assertArrayHasKey('message', $firstWarning);
+        }
+    }
+
+    // ============================================================
+    // Performance Tests
+    // ============================================================
+
+    /**
+     * Test performance with 100 routes
+     *
+     * Should complete analysis in under 1 second
+     */
+    public function testPerformanceWith100Routes(): void
+    {
+        $m = new Mapper();
+
+        // Generate 100 unique routes
+        for ($i = 0; $i < 100; $i++) {
+            $m->connect("route{$i}/:id", [
+                'controller' => "Controller{$i}",
+                'action' => 'show'
+            ]);
+        }
+
+        $this->assertCount(100, $m->matchList);
+
+        $analyzer = new RouteAnalyzer($m);
+
+        $startTime = microtime(true);
+        $warnings = $analyzer->analyze();
+        $duration = microtime(true) - $startTime;
+
+        // Should complete in under 1 second for 100 clean routes
+        $this->assertLessThan(1.0, $duration, 'Should analyze 100 routes in under 1 second');
+
+        // Clean routes should have no warnings
+        $this->assertEmpty($warnings);
+    }
+}

--- a/test/Analysis/RouteAnalyzerTest.php
+++ b/test/Analysis/RouteAnalyzerTest.php
@@ -1,0 +1,406 @@
+<?php
+/**
+ * Horde Routes package
+ *
+ * @author  Ralf Lang <lang@b1-systems.de>
+ * @license http://www.horde.org/licenses/bsd BSD
+ * @package Routes
+ */
+
+namespace Horde\Routes\Test\Analysis;
+
+use PHPUnit\Framework\TestCase;
+use Horde\Routes\Mapper;
+use Horde\Routes\Analysis\RouteAnalyzer;
+
+/**
+ * Unit tests for RouteAnalyzer
+ *
+ * RouteAnalyzer uses runtime verification to detect routing issues by
+ * generating test URLs and verifying which route matches. This approach
+ * avoids false positives from static regex analysis.
+ *
+ * @package Routes
+ */
+class RouteAnalyzerTest extends TestCase
+{
+    // ============================================================
+    // Basic Analysis Tests
+    // ============================================================
+
+    /**
+     * Test that clean configuration returns no warnings
+     */
+    public function testNoIssuesReturnsEmpty(): void
+    {
+        $m = new Mapper();
+        $m->connect('users/:id', ['controller' => 'User', 'action' => 'show']);
+        $m->connect('posts/:id', ['controller' => 'Post', 'action' => 'show']);
+
+        $analyzer = new RouteAnalyzer($m);
+        $warnings = $analyzer->analyze();
+
+        $this->assertIsArray($warnings);
+        $this->assertEmpty($warnings);
+    }
+
+    /**
+     * Test RouteAnalyzer constructor accepts Mapper
+     */
+    public function testConstructorAcceptsMapper(): void
+    {
+        $m = new Mapper();
+        $analyzer = new RouteAnalyzer($m);
+
+        $this->assertInstanceOf(RouteAnalyzer::class, $analyzer);
+    }
+
+    /**
+     * Test verbose mode flag
+     */
+    public function testVerboseModeFlag(): void
+    {
+        $m = new Mapper();
+
+        // Non-verbose (default)
+        $analyzer1 = new RouteAnalyzer($m);
+        $this->assertInstanceOf(RouteAnalyzer::class, $analyzer1);
+
+        // Explicit verbose mode
+        $analyzer2 = new RouteAnalyzer($m, verbose: true);
+        $this->assertInstanceOf(RouteAnalyzer::class, $analyzer2);
+    }
+
+    // ============================================================
+    // Shadowing Detection Tests
+    // ============================================================
+
+    /**
+     * Test static route shadowed by dynamic route
+     *
+     * Example: /users/search (static) shadowed by /users/:action
+     */
+    public function testStaticShadowedByDynamic(): void
+    {
+        $m = new Mapper();
+
+        // Order matters: route defined first has priority
+        $m->connect('users/:action', ['controller' => 'User']);
+        $m->connect('users/search', ['controller' => 'Search', 'action' => 'users']);
+
+        $analyzer = new RouteAnalyzer($m);
+        $warnings = $analyzer->analyze();
+
+        // Should detect that users/search is shadowed
+        $this->assertNotEmpty($warnings);
+
+        // Find the shadowing warning
+        $shadowWarning = null;
+        foreach ($warnings as $warning) {
+            if ($warning['type'] === 'shadowed' &&
+                str_contains($warning['shadowed_route'], 'users/search')) {
+                $shadowWarning = $warning;
+                break;
+            }
+        }
+
+        $this->assertNotNull($shadowWarning, 'Should detect shadowed route');
+        $this->assertStringContainsString('users/:action', $shadowWarning['shadowing_route']);
+    }
+
+    /**
+     * Test dynamic route shadowed by broader dynamic route
+     *
+     * Example: /users/:id shadowed by /users/:action/:id
+     */
+    public function testDynamicShadowedByBroader(): void
+    {
+        $m = new Mapper();
+
+        // Broader pattern first
+        $m->connect('articles/:category/:slug', ['controller' => 'Article', 'action' => 'show']);
+        // More specific pattern
+        $m->connect('articles/:id', ['controller' => 'Article', 'action' => 'show_by_id', 'requirements' => ['id' => '\d+']]);
+
+        $analyzer = new RouteAnalyzer($m);
+        $warnings = $analyzer->analyze();
+
+        // articles/123 will match first route (as "category/slug") instead of second
+        $this->assertNotEmpty($warnings);
+
+        $shadowWarning = null;
+        foreach ($warnings as $warning) {
+            if ($warning['type'] === 'shadowed' &&
+                str_contains($warning['shadowed_route'], 'articles/:id')) {
+                $shadowWarning = $warning;
+                break;
+            }
+        }
+
+        $this->assertNotNull($shadowWarning, 'Should detect shadowed route');
+    }
+
+    /**
+     * Test different HTTP methods do NOT cause shadowing
+     *
+     * GET /users vs POST /users should both be reachable
+     */
+    public function testDifferentHttpMethodsNotShadowed(): void
+    {
+        $m = new Mapper();
+
+        $m->connect('users', ['controller' => 'User', 'action' => 'index', 'conditions' => ['method' => ['GET']]]);
+        $m->connect('users', ['controller' => 'User', 'action' => 'create', 'conditions' => ['method' => ['POST']]]);
+
+        $analyzer = new RouteAnalyzer($m);
+        $warnings = $analyzer->analyze();
+
+        // Should NOT detect shadowing (different HTTP methods)
+        $this->assertEmpty($warnings, 'Different HTTP methods should not shadow each other');
+    }
+
+    /**
+     * Test same pattern with different subdomains
+     *
+     * api.example.com/users vs www.example.com/users
+     */
+    public function testSamePatternDifferentSubdomains(): void
+    {
+        $m = new Mapper();
+        $m->subDomains = true;
+
+        $m->connect('users', ['controller' => 'ApiUser', 'conditions' => ['subdomain' => 'api']]);
+        $m->connect('users', ['controller' => 'WebUser', 'conditions' => ['subdomain' => 'www']]);
+
+        $analyzer = new RouteAnalyzer($m);
+        $warnings = $analyzer->analyze();
+
+        // Should NOT detect shadowing (different subdomains)
+        $this->assertEmpty($warnings, 'Different subdomains should not shadow each other');
+    }
+
+    /**
+     * Test requirements differentiate routes
+     *
+     * /posts/:id with id=\d+ vs /posts/:slug with slug=[a-z-]+
+     * These should NOT shadow if requirements are mutually exclusive
+     */
+    public function testRequirementsDifferentiate(): void
+    {
+        $m = new Mapper();
+
+        // Numeric ID route
+        $m->connect('posts/:id', [
+            'controller' => 'Post',
+            'action' => 'show',
+            'requirements' => ['id' => '\d+']
+        ]);
+
+        // Slug route
+        $m->connect('posts/:slug', [
+            'controller' => 'Post',
+            'action' => 'show_by_slug',
+            'requirements' => ['slug' => '[a-z][a-z0-9-]*']
+        ]);
+
+        $analyzer = new RouteAnalyzer($m);
+        $warnings = $analyzer->analyze();
+
+        // With runtime verification, analyzer tests both numeric and alpha URLs
+        // If requirements work correctly, both routes should be reachable
+        $this->assertEmpty($warnings, 'Mutually exclusive requirements should not cause shadowing');
+    }
+
+    /**
+     * Test one route shadows multiple later routes
+     */
+    public function testMultipleShadowedRoutes(): void
+    {
+        $m = new Mapper();
+
+        // Very broad catch-all route
+        $m->connect(':controller/:action/:id');
+
+        // These more specific routes will all be shadowed
+        $m->connect('users/search', ['controller' => 'Search', 'action' => 'users']);
+        $m->connect('posts/recent', ['controller' => 'Post', 'action' => 'recent']);
+        $m->connect('admin/dashboard', ['controller' => 'Admin', 'action' => 'dashboard']);
+
+        $analyzer = new RouteAnalyzer($m);
+        $warnings = $analyzer->analyze();
+
+        // Should detect all 3 shadowed routes
+        $this->assertCount(3, $warnings);
+
+        foreach ($warnings as $warning) {
+            $this->assertEquals('shadowed', $warning['type']);
+        }
+    }
+
+    // ============================================================
+    // Test URL Generation Tests
+    // ============================================================
+
+    /**
+     * Test analyzer generates URLs from simple placeholders
+     *
+     * :id should generate something like "123"
+     * :slug should generate something like "test-slug"
+     */
+    public function testGenerateSimplePlaceholders(): void
+    {
+        $m = new Mapper();
+        $m->connect('posts/:id/comments/:comment_id', ['controller' => 'Comment', 'action' => 'show']);
+
+        $analyzer = new RouteAnalyzer($m);
+        $testUrls = $analyzer->getTestUrls();
+
+        // Should have generated test URLs for this route
+        $this->assertNotEmpty($testUrls);
+
+        // Test URLs should contain numeric values for :id placeholders
+        $found = false;
+        foreach ($testUrls as $url) {
+            if (preg_match('#posts/\d+/comments/\d+#', $url)) {
+                $found = true;
+                break;
+            }
+        }
+
+        $this->assertTrue($found, 'Should generate test URLs with numeric values for :id placeholders');
+    }
+
+    /**
+     * Test analyzer generates URLs from regex requirements
+     *
+     * \d+ should generate numeric values
+     * [a-z]+ should generate alphabetic strings
+     */
+    public function testGenerateFromRegex(): void
+    {
+        $m = new Mapper();
+        $m->connect('posts/:year/:month/:day', [
+            'controller' => 'Post',
+            'action' => 'by_date',
+            'requirements' => [
+                'year' => '\d{4}',
+                'month' => '\d{2}',
+                'day' => '\d{2}'
+            ]
+        ]);
+
+        $analyzer = new RouteAnalyzer($m);
+        $testUrls = $analyzer->getTestUrls();
+
+        $this->assertNotEmpty($testUrls);
+
+        // Should generate URLs matching the pattern
+        $found = false;
+        foreach ($testUrls as $url) {
+            if (preg_match('#posts/\d{4}/\d{2}/\d{2}#', $url)) {
+                $found = true;
+                break;
+            }
+        }
+
+        $this->assertTrue($found, 'Should generate test URLs matching regex requirements');
+    }
+
+    /**
+     * Test analyzer generates multiple test URLs per route
+     *
+     * To thoroughly test for shadowing, should generate 2-3 variants
+     */
+    public function testMultipleTestUrlsPerRoute(): void
+    {
+        $m = new Mapper();
+        $m->connect('posts/:id', ['controller' => 'Post', 'action' => 'show']);
+
+        $analyzer = new RouteAnalyzer($m);
+        $testUrls = $analyzer->getTestUrls();
+
+        // Should generate multiple test URLs (at least 2)
+        $postUrls = array_filter($testUrls, fn($url) => str_contains($url, 'posts/'));
+        $this->assertGreaterThanOrEqual(2, count($postUrls), 'Should generate multiple test URLs per route');
+    }
+
+    // ============================================================
+    // Other Detection Tests
+    // ============================================================
+
+    /**
+     * Test detection of invalid regex in requirements
+     */
+    public function testInvalidRegexDetected(): void
+    {
+        $m = new Mapper();
+
+        // Invalid regex: unclosed bracket
+        $m->connect('posts/:id', [
+            'controller' => 'Post',
+            'action' => 'show',
+            'requirements' => ['id' => '[0-9']  // Invalid: unclosed [
+        ]);
+
+        $analyzer = new RouteAnalyzer($m);
+        $warnings = $analyzer->analyze();
+
+        // Should detect invalid regex
+        $this->assertNotEmpty($warnings);
+
+        $invalidRegex = null;
+        foreach ($warnings as $warning) {
+            if ($warning['type'] === 'invalid_requirement') {
+                $invalidRegex = $warning;
+                break;
+            }
+        }
+
+        $this->assertNotNull($invalidRegex, 'Should detect invalid regex in requirements');
+        $this->assertStringContainsString('id', $invalidRegex['message']);
+    }
+
+    /**
+     * Test detection of duplicate routes
+     *
+     * Two routes with exact same path and conditions
+     */
+    public function testDuplicateRoutesDetected(): void
+    {
+        $m = new Mapper();
+
+        // Exact duplicates
+        $m->connect('users/:id', ['controller' => 'User', 'action' => 'show']);
+        $m->connect('users/:id', ['controller' => 'User', 'action' => 'show']);
+
+        $analyzer = new RouteAnalyzer($m);
+        $warnings = $analyzer->analyze();
+
+        // Should detect duplicate
+        $this->assertNotEmpty($warnings);
+
+        $duplicate = null;
+        foreach ($warnings as $warning) {
+            if ($warning['type'] === 'duplicate') {
+                $duplicate = $warning;
+                break;
+            }
+        }
+
+        $this->assertNotNull($duplicate, 'Should detect duplicate routes');
+    }
+
+    /**
+     * Test empty mapper returns no warnings
+     */
+    public function testEmptyMapperReturnsNoWarnings(): void
+    {
+        $m = new Mapper();
+
+        $analyzer = new RouteAnalyzer($m);
+        $warnings = $analyzer->analyze();
+
+        $this->assertIsArray($warnings);
+        $this->assertEmpty($warnings);
+    }
+}

--- a/test/FluentRouteBuilderTest.php
+++ b/test/FluentRouteBuilderTest.php
@@ -1,0 +1,274 @@
+<?php
+/**
+ * Horde Routes package
+ *
+ * @author  Ralf Lang <lang@b1-systems.de>
+ * @license http://www.horde.org/licenses/bsd BSD
+ * @package Routes
+ */
+
+namespace Horde\Routes\Test;
+
+use PHPUnit\Framework\TestCase;
+use Horde\Routes\Mapper;
+use Horde\Routes\FluentRouteBuilder;
+use Horde\Routes\RouteBuilder;
+
+/**
+ * Tests for FluentRouteBuilder wrapper
+ *
+ * FluentRouteBuilder wraps RouteBuilder and adds the ->add() method
+ * that returns the Mapper for chaining. This enables the fluent API:
+ *   $mapper->route('path')->controller('Foo')->add()
+ *
+ * @package Routes
+ */
+class FluentRouteBuilderTest extends TestCase
+{
+    /**
+     * Test FluentRouteBuilder constructor
+     */
+    public function testConstructor(): void
+    {
+        $m = new Mapper();
+        $fluent = new FluentRouteBuilder($m, 'users/:id');
+
+        $this->assertInstanceOf(FluentRouteBuilder::class, $fluent);
+
+        // Should have access to underlying builder
+        $builder = $fluent->getBuilder();
+        $this->assertInstanceOf(RouteBuilder::class, $builder);
+    }
+
+    /**
+     * Test methods proxy to underlying RouteBuilder
+     */
+    public function testFluentProxying(): void
+    {
+        $m = new Mapper();
+        $fluent = new FluentRouteBuilder($m, 'users/:id');
+
+        // All RouteBuilder methods should be available
+        $result = $fluent->controller('User')
+                         ->action('show')
+                         ->requires('id', '\d+')
+                         ->get()
+                         ->middleware(['Auth']);
+
+        // Should return FluentRouteBuilder (self) for chaining
+        $this->assertInstanceOf(FluentRouteBuilder::class, $result);
+        $this->assertSame($fluent, $result);
+
+        // Underlying builder should have the configuration
+        $builder = $fluent->getBuilder();
+        $config = $builder->toArray();
+
+        $this->assertEquals('User', $config['controller']);
+        $this->assertEquals('show', $config['action']);
+        $this->assertEquals('\d+', $config['requirements']['id']);
+        $this->assertEquals(['GET'], $config['conditions']['method']);
+        $this->assertEquals(['Auth'], $config['stack']);
+    }
+
+    /**
+     * Test add() method returns Mapper for chaining
+     */
+    public function testAddMethodReturnsMapper(): void
+    {
+        $m = new Mapper();
+        $fluent = new FluentRouteBuilder($m, 'users/:id');
+
+        $result = $fluent->controller('User')
+                         ->action('show')
+                         ->add();
+
+        // Should return the original Mapper
+        $this->assertSame($m, $result);
+
+        // Route should be added to Mapper
+        $this->assertCount(1, $m->matchList);
+        $this->assertEquals('users/:id', $m->matchList[0]->routePath);
+    }
+
+    /**
+     * Test complex chain: multiple routes
+     */
+    public function testComplexChain(): void
+    {
+        $m = new Mapper();
+
+        // Chain multiple routes
+        $m->route('users')
+          ->controller('User')
+          ->action('index')
+          ->get()
+          ->add()
+          ->route('users')
+          ->controller('User')
+          ->action('create')
+          ->post()
+          ->add()
+          ->route('users/:id')
+          ->controller('User')
+          ->action('show')
+          ->requires('id', '\d+')
+          ->get()
+          ->add()
+          ->route('users/:id')
+          ->controller('User')
+          ->action('update')
+          ->requires('id', '\d+')
+          ->put()
+          ->add()
+          ->route('users/:id')
+          ->controller('User')
+          ->action('delete')
+          ->requires('id', '\d+')
+          ->delete()
+          ->add();
+
+        // Should have all 5 routes
+        $this->assertCount(5, $m->matchList);
+
+        // Verify first route
+        $this->assertEquals('users', $m->matchList[0]->routePath);
+        $this->assertEquals('index', $m->matchList[0]->defaults['action']);
+
+        // Verify last route
+        $this->assertEquals('users/:id', $m->matchList[4]->routePath);
+        $this->assertEquals('delete', $m->matchList[4]->defaults['action']);
+    }
+
+    /**
+     * Test named route with fluent API
+     */
+    public function testNamedRouteWithFluent(): void
+    {
+        $m = new Mapper();
+
+        $m->route('users/:id')
+          ->name('user_show')
+          ->controller('User')
+          ->action('show')
+          ->add();
+
+        // Named route should be registered
+        $this->assertArrayHasKey('user_show', $m->routeNames);
+    }
+
+    /**
+     * Test secondary route with fluent API
+     */
+    public function testSecondaryRouteWithFluent(): void
+    {
+        $m = new Mapper();
+
+        $m->route('users/:id')
+          ->controller('User')
+          ->action('show')
+          ->add()
+          ->route('profile/:id')
+          ->controller('User')
+          ->action('show')
+          ->secondary()
+          ->add();
+
+        $this->assertCount(2, $m->matchList);
+        $this->assertFalse($m->matchList[0]->secondary);
+        $this->assertTrue($m->matchList[1]->secondary);
+    }
+
+    /**
+     * Test method proxying edge cases
+     */
+    public function testMethodProxyingEdgeCases(): void
+    {
+        $m = new Mapper();
+        $fluent = new FluentRouteBuilder($m, 'test/:id');
+
+        // Test withDefaults (array parameter)
+        $fluent->withDefaults([
+            'controller' => 'Test',
+            'action' => 'show'
+        ]);
+
+        $builder = $fluent->getBuilder();
+        $config = $builder->toArray();
+        $this->assertEquals('Test', $config['controller']);
+        $this->assertEquals('show', $config['action']);
+
+        // Test withRequirements (array parameter)
+        $fluent->withRequirements([
+            'id' => '\d+',
+            'format' => 'json|xml'
+        ]);
+
+        $config = $builder->toArray();
+        $this->assertEquals('\d+', $config['requirements']['id']);
+        $this->assertEquals('json|xml', $config['requirements']['format']);
+
+        // Test methods (array parameter)
+        $fluent->methods(['GET', 'HEAD']);
+
+        $config = $builder->toArray();
+        $this->assertEquals(['GET', 'HEAD'], $config['conditions']['method']);
+    }
+
+    /**
+     * Test that undefined methods throw error
+     */
+    public function testUndefinedMethodThrows(): void
+    {
+        $m = new Mapper();
+        $fluent = new FluentRouteBuilder($m, 'test');
+
+        $this->expectException(\Error::class);
+        $fluent->nonExistentMethod();
+    }
+
+    /**
+     * Test real-world usage pattern
+     */
+    public function testRealWorldUsagePattern(): void
+    {
+        $m = new Mapper();
+
+        // Define an API with multiple endpoints
+        $m->route('api/v1/users')
+          ->name('api_users_list')
+          ->controller('Api\\V1\\User')
+          ->action('index')
+          ->middleware(['ApiAuth', 'RateLimit'])
+          ->get()
+          ->add()
+
+          ->route('api/v1/users/:id')
+          ->name('api_users_show')
+          ->controller('Api\\V1\\User')
+          ->action('show')
+          ->requires('id', '\d+')
+          ->middleware(['ApiAuth', 'RateLimit'])
+          ->methods(['GET', 'HEAD'])
+          ->add()
+
+          ->route('api/v1/users')
+          ->name('api_users_create')
+          ->controller('Api\\V1\\User')
+          ->action('create')
+          ->middleware(['ApiAuth', 'RateLimit', 'ValidateJson'])
+          ->post()
+          ->add();
+
+        // Verify all routes added
+        $this->assertCount(3, $m->matchList);
+
+        // Verify all are named
+        $this->assertArrayHasKey('api_users_list', $m->routeNames);
+        $this->assertArrayHasKey('api_users_show', $m->routeNames);
+        $this->assertArrayHasKey('api_users_create', $m->routeNames);
+
+        // Verify middleware on first route
+        $route = $m->routeNames['api_users_list'];
+        $this->assertEquals(['ApiAuth', 'RateLimit'], $route->stack);
+    }
+}

--- a/test/MatcherTest.php
+++ b/test/MatcherTest.php
@@ -25,15 +25,22 @@ use Horde_Support_Array;
 class TestRequest
 {
     private string $path;
+    private string $method;
 
-    public function __construct(string $path)
+    public function __construct(string $path, string $method = 'GET')
     {
         $this->path = $path;
+        $this->method = $method;
     }
 
     public function getPath(): string
     {
         return $this->path;
+    }
+
+    public function getMethod(): string
+    {
+        return $this->method;
     }
 }
 
@@ -285,5 +292,90 @@ class MatcherTest extends TestCase
         $this->assertEquals('johndoe', $matchDict['username']);
         $this->assertEquals('42', $matchDict['post_id']);
         $this->assertEquals('7', $matchDict['id']);
+    }
+
+    /**
+     * Test matcher automatically populates environ from request
+     */
+    public function testMatcherPopulatesEnvironFromRequest(): void
+    {
+        $mapper = new Mapper();
+
+        // Create routes that depend on HTTP method
+        $mapper->resource('message', 'messages');
+        $mapper->createRegs(['messages']);
+
+        // Before creating matcher, environ should be empty or default
+        $this->assertEmpty($mapper->environ);
+
+        // Create request with GET method
+        $request = new TestRequest('/messages');
+
+        // Create matcher - should auto-populate environ
+        $matcher = new Matcher($mapper, $request);
+        $matchDict = $matcher->getMatchDict();
+
+        // Verify environ was populated from request
+        $this->assertArrayHasKey('REQUEST_METHOD', $mapper->environ);
+        $this->assertEquals('GET', $mapper->environ['REQUEST_METHOD']);
+
+        // Verify route matched correctly with method
+        $this->assertEquals('messages', $matchDict['controller']);
+        $this->assertEquals('index', $matchDict['action']);
+    }
+
+    /**
+     * Test matcher respects HTTP method for RESTful routes
+     */
+    public function testMatcherRespectsHttpMethodForResources(): void
+    {
+        $mapper = new Mapper();
+        $mapper->resource('post', 'posts');
+        $mapper->createRegs(['posts']);
+
+        // Test GET /posts (index action)
+        $getRequest = new TestRequest('/posts', 'GET');
+        $getMatcher = new Matcher($mapper, $getRequest);
+        $getMatch = $getMatcher->getMatchDict();
+
+        $this->assertEquals('posts', $getMatch['controller']);
+        $this->assertEquals('index', $getMatch['action']);
+        $this->assertEquals('GET', $mapper->environ['REQUEST_METHOD']);
+
+        // Test POST /posts (create action)
+        $postRequest = new TestRequest('/posts', 'POST');
+        $postMatcher = new Matcher($mapper, $postRequest);
+        $postMatch = $postMatcher->getMatchDict();
+
+        $this->assertEquals('posts', $postMatch['controller']);
+        $this->assertEquals('create', $postMatch['action']);
+        $this->assertEquals('POST', $mapper->environ['REQUEST_METHOD']);
+    }
+
+    /**
+     * Test matcher works without setting environ manually
+     */
+    public function testMatcherWorksWithoutManualEnvironSetup(): void
+    {
+        $mapper = new Mapper();
+
+        // Define route that works regardless of method
+        $mapper->connect('blog/:action/:id', ['controller' => 'blog']);
+        $mapper->createRegs(['blog']);
+
+        // DON'T manually set environ (this is what we're testing)
+        // $mapper->environ = ['REQUEST_METHOD' => 'GET']; // OLD WAY
+
+        $request = new TestRequest('/blog/view/123');
+        $matcher = new Matcher($mapper, $request);
+        $matchDict = $matcher->getMatchDict();
+
+        // Should work even without manual environ setup
+        $this->assertEquals('blog', $matchDict['controller']);
+        $this->assertEquals('view', $matchDict['action']);
+        $this->assertEquals('123', $matchDict['id']);
+
+        // Environ should have been auto-populated
+        $this->assertArrayHasKey('REQUEST_METHOD', $mapper->environ);
     }
 }

--- a/test/RouteBuilderIntegrationTest.php
+++ b/test/RouteBuilderIntegrationTest.php
@@ -1,0 +1,326 @@
+<?php
+/**
+ * Horde Routes package
+ *
+ * @author  Ralf Lang <lang@b1-systems.de>
+ * @license http://www.horde.org/licenses/bsd BSD
+ * @package Routes
+ */
+
+namespace Horde\Routes\Test;
+
+use PHPUnit\Framework\TestCase;
+use Horde\Routes\Mapper;
+use Horde\Routes\RouteBuilder;
+use Horde\Routes\Route;
+
+/**
+ * Integration tests for RouteBuilder with Mapper
+ *
+ * Tests the interaction between RouteBuilder and Mapper to ensure
+ * routes built with the fluent API work correctly for matching and generation.
+ *
+ * @package Routes
+ * @group integration
+ */
+class RouteBuilderIntegrationTest extends TestCase
+{
+    /**
+     * Test Mapper->addRoute() accepts RouteBuilder
+     */
+    public function testMapperAddRouteMethod(): void
+    {
+        $m = new Mapper();
+
+        // Create builder
+        $builder = new RouteBuilder('api/users/:id');
+        $builder->controller('User')
+                ->action('show')
+                ->requires('id', '\d+')
+                ->get();
+
+        // Add to mapper
+        $m->addRoute($builder);
+
+        // Should be in matchList
+        $this->assertCount(1, $m->matchList);
+
+        // Should be a Route object
+        $this->assertInstanceOf(Route::class, $m->matchList[0]);
+
+        // Should have correct path
+        $this->assertEquals('api/users/:id', $m->matchList[0]->routePath);
+    }
+
+    /**
+     * Test Mapper->route()->add() fluent API
+     */
+    public function testMapperRouteHelperMethod(): void
+    {
+        $m = new Mapper();
+
+        // Use fluent API
+        $result = $m->route('users/:id')
+                    ->controller('User')
+                    ->action('show')
+                    ->requires('id', '\d+')
+                    ->get()
+                    ->add();
+
+        // Should return Mapper for chaining
+        $this->assertSame($m, $result);
+
+        // Route should be added
+        $this->assertCount(1, $m->matchList);
+
+        // Can chain multiple routes
+        $m->route('users')
+          ->controller('User')
+          ->action('index')
+          ->get()
+          ->add()
+          ->route('users')
+          ->controller('User')
+          ->action('create')
+          ->post()
+          ->add();
+
+        // Should have 3 routes total
+        $this->assertCount(3, $m->matchList);
+    }
+
+    /**
+     * Test route built with builder matches URLs
+     */
+    public function testBuiltRouteMatches(): void
+    {
+        $m = new Mapper();
+
+        // Build route with fluent API
+        $m->route('api/users/:id')
+          ->controller('User')
+          ->action('show')
+          ->requires('id', '\d+')
+          ->middleware(['Auth', 'JsonResponse'])
+          ->get()
+          ->add();
+
+        // Set environ for GET request
+        $m->environ = ['REQUEST_METHOD' => 'GET'];
+
+        // Should match valid URL
+        $result = $m->match('/api/users/123');
+        $this->assertIsArray($result);
+        $this->assertEquals('User', $result['controller']);
+        $this->assertEquals('show', $result['action']);
+        $this->assertEquals('123', $result['id']);
+        $this->assertEquals(['Auth', 'JsonResponse'], $result['stack']);
+
+        // Should not match invalid ID
+        $this->assertNull($m->match('/api/users/abc'));
+
+        // Should not match POST request
+        $m->environ = ['REQUEST_METHOD' => 'POST'];
+        $this->assertNull($m->match('/api/users/123'));
+    }
+
+    /**
+     * Test route built with builder generates URLs
+     */
+    public function testBuiltRouteGenerates(): void
+    {
+        $m = new Mapper();
+
+        // Add route with name
+        $m->route('users/:id/profile')
+          ->name('user_profile')
+          ->controller('User')
+          ->action('profile')
+          ->requires('id', '\d+')
+          ->add();
+
+        // Should generate URL
+        $url = $m->generate([
+            'controller' => 'User',
+            'action' => 'profile',
+            'id' => '42'
+        ]);
+
+        $this->assertEquals('/users/42/profile', $url);
+    }
+
+    /**
+     * Test mixed array-based and builder-based routes
+     */
+    public function testMixedApiRoutes(): void
+    {
+        $m = new Mapper();
+
+        // Add array-based route
+        $m->connect('old/path/:id', [
+            'controller' => 'Old',
+            'action' => 'show'
+        ]);
+
+        // Add builder-based route
+        $m->route('new/path/:id')
+          ->controller('New')
+          ->action('show')
+          ->add();
+
+        // Both should work
+        $this->assertCount(2, $m->matchList);
+
+        $result1 = $m->match('/old/path/123');
+        $this->assertEquals('Old', $result1['controller']);
+
+        $result2 = $m->match('/new/path/456');
+        $this->assertEquals('New', $result2['controller']);
+
+        // Both should generate
+        $url1 = $m->generate(['controller' => 'Old', 'action' => 'show', 'id' => '1']);
+        $this->assertEquals('/old/path/1', $url1);
+
+        $url2 = $m->generate(['controller' => 'New', 'action' => 'show', 'id' => '2']);
+        $this->assertEquals('/new/path/2', $url2);
+    }
+
+    /**
+     * Test builder with secondary flag
+     */
+    public function testBuilderWithSecondary(): void
+    {
+        $m = new Mapper();
+
+        // Primary route
+        $m->route('users/:id')
+          ->controller('User')
+          ->action('show')
+          ->add();
+
+        // Secondary route (legacy)
+        $m->route('profile/:id')
+          ->controller('User')
+          ->action('show')
+          ->secondary()
+          ->add();
+
+        // Both should match
+        $this->assertNotNull($m->match('/users/123'));
+        $this->assertNotNull($m->match('/profile/123'));
+
+        // But only primary generates
+        $url = $m->generate(['controller' => 'User', 'action' => 'show', 'id' => '42']);
+        $this->assertEquals('/users/42', $url);
+    }
+
+    /**
+     * Test builder with named route
+     */
+    public function testBuilderWithNamedRoute(): void
+    {
+        $m = new Mapper();
+
+        $m->route('api/v2/users/:id')
+          ->name('api_user_show')
+          ->controller('Api\\User')
+          ->action('show')
+          ->requires('id', '\d+')
+          ->add();
+
+        // Named route should be in routeNames
+        $this->assertArrayHasKey('api_user_show', $m->routeNames);
+        $this->assertInstanceOf(Route::class, $m->routeNames['api_user_show']);
+
+        // Should be able to match
+        $result = $m->match('/api/v2/users/99');
+        $this->assertEquals('Api\\User', $result['controller']);
+    }
+
+    /**
+     * Test builder with noMiddleware()
+     */
+    public function testBuilderWithNoMiddleware(): void
+    {
+        $m = new Mapper();
+
+        // Public route with no middleware
+        $m->route('public/health')
+          ->controller('Public')
+          ->action('health')
+          ->noMiddleware()
+          ->add();
+
+        $result = $m->match('/public/health');
+
+        // Should have empty stack
+        $this->assertArrayHasKey('stack', $result);
+        $this->assertIsArray($result['stack']);
+        $this->assertEmpty($result['stack']);
+    }
+
+    /**
+     * Test complex RESTful routes with builder
+     */
+    public function testRESTfulRoutesWithBuilder(): void
+    {
+        $m = new Mapper();
+
+        // Define RESTful resource
+        $m->route('posts')
+          ->controller('Post')
+          ->action('index')
+          ->get()
+          ->add()
+          ->route('posts')
+          ->controller('Post')
+          ->action('create')
+          ->post()
+          ->add()
+          ->route('posts/:id')
+          ->controller('Post')
+          ->action('show')
+          ->requires('id', '\d+')
+          ->get()
+          ->add()
+          ->route('posts/:id')
+          ->controller('Post')
+          ->action('update')
+          ->requires('id', '\d+')
+          ->put()
+          ->add()
+          ->route('posts/:id')
+          ->controller('Post')
+          ->action('delete')
+          ->requires('id', '\d+')
+          ->delete()
+          ->add();
+
+        $this->assertCount(5, $m->matchList);
+
+        // Test GET collection
+        $m->environ = ['REQUEST_METHOD' => 'GET'];
+        $result1 = $m->match('/posts');
+        $this->assertEquals('index', $result1['action']);
+
+        // Test GET member
+        $result2 = $m->match('/posts/42');
+        $this->assertEquals('show', $result2['action']);
+        $this->assertEquals('42', $result2['id']);
+
+        // Test POST
+        $m->environ = ['REQUEST_METHOD' => 'POST'];
+        $result3 = $m->match('/posts');
+        $this->assertEquals('create', $result3['action']);
+
+        // Test PUT
+        $m->environ = ['REQUEST_METHOD' => 'PUT'];
+        $result4 = $m->match('/posts/42');
+        $this->assertEquals('update', $result4['action']);
+
+        // Test DELETE
+        $m->environ = ['REQUEST_METHOD' => 'DELETE'];
+        $result5 = $m->match('/posts/42');
+        $this->assertEquals('delete', $result5['action']);
+    }
+}

--- a/test/RouteBuilderTest.php
+++ b/test/RouteBuilderTest.php
@@ -1,0 +1,443 @@
+<?php
+/**
+ * Horde Routes package
+ *
+ * @author  Ralf Lang <lang@b1-systems.de>
+ * @license http://www.horde.org/licenses/bsd BSD
+ * @package Routes
+ */
+
+namespace Horde\Routes\Test;
+
+use PHPUnit\Framework\TestCase;
+use Horde\Routes\RouteBuilder;
+use Horde\Routes\Route;
+
+/**
+ * Unit tests for RouteBuilder fluent API
+ *
+ * These tests document the expected behavior of the RouteBuilder class.
+ * They should fail until RouteBuilder is implemented.
+ *
+ * @package Routes
+ */
+class RouteBuilderTest extends TestCase
+{
+    // ============================================================
+    // Basic Builder Tests
+    // ============================================================
+
+    /**
+     * Test RouteBuilder constructor accepts path
+     */
+    public function testConstructorWithPath(): void
+    {
+        $builder = new RouteBuilder('users/:id');
+
+        $this->assertInstanceOf(RouteBuilder::class, $builder);
+
+        // Should be able to build a route
+        $route = $builder->build();
+        $this->assertInstanceOf(Route::class, $route);
+        $this->assertEquals('users/:id', $route->routePath);
+    }
+
+    /**
+     * Test name() method sets route name
+     */
+    public function testNameMethod(): void
+    {
+        $builder = new RouteBuilder('users/:id');
+        $result = $builder->name('user_show');
+
+        // Should return self for chaining
+        $this->assertSame($builder, $result);
+
+        // Name should be retrievable
+        $this->assertEquals('user_show', $builder->getName());
+    }
+
+    /**
+     * Test controller() method sets controller default
+     */
+    public function testControllerMethod(): void
+    {
+        $builder = new RouteBuilder('users/:id');
+        $result = $builder->controller('User');
+
+        $this->assertSame($builder, $result);
+
+        $config = $builder->toArray();
+        $this->assertEquals('User', $config['controller']);
+    }
+
+    /**
+     * Test action() method sets action default
+     */
+    public function testActionMethod(): void
+    {
+        $builder = new RouteBuilder('users/:id');
+        $result = $builder->action('show');
+
+        $this->assertSame($builder, $result);
+
+        $config = $builder->toArray();
+        $this->assertEquals('show', $config['action']);
+    }
+
+    /**
+     * Test defaults() method sets arbitrary default
+     */
+    public function testDefaultsMethod(): void
+    {
+        $builder = new RouteBuilder('posts/:slug');
+        $result = $builder->defaults('format', 'html');
+
+        $this->assertSame($builder, $result);
+
+        $config = $builder->toArray();
+        $this->assertEquals('html', $config['format']);
+    }
+
+    // ============================================================
+    // Requirements & Conditions Tests
+    // ============================================================
+
+    /**
+     * Test requires() method adds requirement
+     */
+    public function testRequiresMethod(): void
+    {
+        $builder = new RouteBuilder('users/:id');
+        $result = $builder->requires('id', '\d+');
+
+        $this->assertSame($builder, $result);
+
+        $config = $builder->toArray();
+        $this->assertArrayHasKey('requirements', $config);
+        $this->assertEquals('\d+', $config['requirements']['id']);
+    }
+
+    /**
+     * Test withRequirements() adds multiple requirements
+     */
+    public function testWithRequirements(): void
+    {
+        $builder = new RouteBuilder('posts/:year/:month/:day');
+        $result = $builder->withRequirements([
+            'year' => '\d{4}',
+            'month' => '\d{2}',
+            'day' => '\d{2}'
+        ]);
+
+        $this->assertSame($builder, $result);
+
+        $config = $builder->toArray();
+        $this->assertEquals('\d{4}', $config['requirements']['year']);
+        $this->assertEquals('\d{2}', $config['requirements']['month']);
+        $this->assertEquals('\d{2}', $config['requirements']['day']);
+    }
+
+    /**
+     * Test HTTP method shorthand methods
+     */
+    public function testHttpMethodShorthand(): void
+    {
+        // Test get()
+        $builder1 = new RouteBuilder('users');
+        $builder1->get();
+        $config1 = $builder1->toArray();
+        $this->assertEquals(['GET'], $config1['conditions']['method']);
+
+        // Test post()
+        $builder2 = new RouteBuilder('users');
+        $builder2->post();
+        $config2 = $builder2->toArray();
+        $this->assertEquals(['POST'], $config2['conditions']['method']);
+
+        // Test put()
+        $builder3 = new RouteBuilder('users/:id');
+        $builder3->put();
+        $config3 = $builder3->toArray();
+        $this->assertEquals(['PUT'], $config3['conditions']['method']);
+
+        // Test delete()
+        $builder4 = new RouteBuilder('users/:id');
+        $builder4->delete();
+        $config4 = $builder4->toArray();
+        $this->assertEquals(['DELETE'], $config4['conditions']['method']);
+
+        // Test patch()
+        $builder5 = new RouteBuilder('users/:id');
+        $builder5->patch();
+        $config5 = $builder5->toArray();
+        $this->assertEquals(['PATCH'], $config5['conditions']['method']);
+    }
+
+    /**
+     * Test methods() with array of HTTP methods
+     */
+    public function testMethodsArray(): void
+    {
+        $builder = new RouteBuilder('users/:id');
+        $result = $builder->methods(['GET', 'HEAD']);
+
+        $this->assertSame($builder, $result);
+
+        $config = $builder->toArray();
+        $this->assertEquals(['GET', 'HEAD'], $config['conditions']['method']);
+    }
+
+    /**
+     * Test subdomain() condition
+     */
+    public function testSubdomainCondition(): void
+    {
+        $builder = new RouteBuilder('api/users');
+        $result = $builder->subdomain('api');
+
+        $this->assertSame($builder, $result);
+
+        $config = $builder->toArray();
+        $this->assertEquals('api', $config['conditions']['subdomain']);
+    }
+
+    /**
+     * Test where() custom condition function
+     */
+    public function testWhereFunction(): void
+    {
+        $builder = new RouteBuilder('special/:id');
+        $callable = function($environ) { return true; };
+        $result = $builder->where($callable);
+
+        $this->assertSame($builder, $result);
+
+        $config = $builder->toArray();
+        $this->assertSame($callable, $config['conditions']['function']);
+    }
+
+    // ============================================================
+    // Middleware & Flags Tests
+    // ============================================================
+
+    /**
+     * Test middleware() sets middleware stack
+     */
+    public function testMiddlewareStack(): void
+    {
+        $builder = new RouteBuilder('api/users');
+        $result = $builder->middleware(['ApiAuth', 'RateLimit']);
+
+        $this->assertSame($builder, $result);
+
+        $config = $builder->toArray();
+        $this->assertEquals(['ApiAuth', 'RateLimit'], $config['stack']);
+    }
+
+    /**
+     * Test noMiddleware() sets empty stack
+     */
+    public function testNoMiddleware(): void
+    {
+        $builder = new RouteBuilder('public/health');
+        $result = $builder->noMiddleware();
+
+        $this->assertSame($builder, $result);
+
+        $config = $builder->toArray();
+        $this->assertIsArray($config['stack']);
+        $this->assertEmpty($config['stack']);
+    }
+
+    /**
+     * Test secondary() flag marks route as non-generative
+     */
+    public function testSecondaryFlag(): void
+    {
+        $builder = new RouteBuilder('legacy/users/:id');
+        $result = $builder->secondary();
+
+        $this->assertSame($builder, $result);
+
+        $config = $builder->toArray();
+        $this->assertTrue($config['_secondary']);
+
+        // Test with explicit false
+        $builder2 = new RouteBuilder('users/:id');
+        $builder2->secondary(false);
+        $config2 = $builder2->toArray();
+        $this->assertArrayNotHasKey('_secondary', $config2);
+    }
+
+    /**
+     * Test absolute() flag marks route as absolute
+     */
+    public function testAbsoluteFlag(): void
+    {
+        $builder = new RouteBuilder('/absolute/path');
+        $result = $builder->absolute();
+
+        $this->assertSame($builder, $result);
+
+        $config = $builder->toArray();
+        $this->assertTrue($config['_absolute']);
+    }
+
+    // ============================================================
+    // Builder Output Tests
+    // ============================================================
+
+    /**
+     * Test toArray() produces correct structure
+     */
+    public function testToArrayFormat(): void
+    {
+        $builder = new RouteBuilder('api/users/:id');
+        $builder->controller('User')
+                ->action('show')
+                ->requires('id', '\d+')
+                ->get()
+                ->middleware(['Auth']);
+
+        $config = $builder->toArray();
+
+        // Check defaults
+        $this->assertEquals('User', $config['controller']);
+        $this->assertEquals('show', $config['action']);
+
+        // Check requirements
+        $this->assertArrayHasKey('requirements', $config);
+        $this->assertEquals('\d+', $config['requirements']['id']);
+
+        // Check conditions
+        $this->assertArrayHasKey('conditions', $config);
+        $this->assertEquals(['GET'], $config['conditions']['method']);
+
+        // Check stack
+        $this->assertEquals(['Auth'], $config['stack']);
+    }
+
+    /**
+     * Test build() creates valid Route object
+     */
+    public function testBuildCreatesRoute(): void
+    {
+        $builder = new RouteBuilder('users/:id');
+        $builder->controller('User')
+                ->action('show')
+                ->requires('id', '\d+');
+
+        $route = $builder->build();
+
+        $this->assertInstanceOf(Route::class, $route);
+        $this->assertEquals('users/:id', $route->routePath);
+        $this->assertEquals('User', $route->defaults['controller']);
+        $this->assertEquals('show', $route->defaults['action']);
+        $this->assertEquals('\d+', $route->reqs['id']);
+    }
+
+    /**
+     * Test all methods return self for fluent chaining
+     */
+    public function testFluentChaining(): void
+    {
+        $builder = new RouteBuilder('users/:id');
+
+        // Chain multiple methods
+        $result = $builder
+            ->name('user_show')
+            ->controller('User')
+            ->action('show')
+            ->requires('id', '\d+')
+            ->get()
+            ->middleware(['Auth'])
+            ->secondary(false)
+            ->absolute(false);
+
+        // Final result should be the same builder instance
+        $this->assertSame($builder, $result);
+
+        // Should be able to build after chaining
+        $route = $builder->build();
+        $this->assertInstanceOf(Route::class, $route);
+    }
+
+    // ============================================================
+    // Edge Cases
+    // ============================================================
+
+    /**
+     * Test method called twice - last wins
+     */
+    public function testMethodCalledTwiceLastWins(): void
+    {
+        $builder = new RouteBuilder('users/:id');
+        $builder->controller('User')
+                ->controller('Admin');
+
+        $config = $builder->toArray();
+        $this->assertEquals('Admin', $config['controller']);
+    }
+
+    /**
+     * Test withDefaults() merges with existing defaults
+     */
+    public function testWithDefaultsMerges(): void
+    {
+        $builder = new RouteBuilder('posts/:id');
+        $builder->controller('Post')
+                ->withDefaults([
+                    'action' => 'show',
+                    'format' => 'html'
+                ]);
+
+        $config = $builder->toArray();
+        $this->assertEquals('Post', $config['controller']);
+        $this->assertEquals('show', $config['action']);
+        $this->assertEquals('html', $config['format']);
+    }
+
+    /**
+     * Test null values in defaults
+     */
+    public function testNullValuesInDefaults(): void
+    {
+        $builder = new RouteBuilder('posts');
+        $builder->defaults('page', null);
+
+        $config = $builder->toArray();
+        $this->assertArrayHasKey('page', $config);
+        $this->assertNull($config['page']);
+    }
+
+    /**
+     * Test complex real-world route
+     */
+    public function testComplexRealWorldRoute(): void
+    {
+        $builder = new RouteBuilder('api/v2/:resource/:id');
+        $builder->name('api_resource_show')
+                ->requires('id', '\d+')
+                ->methods(['GET', 'HEAD'])
+                ->middleware(['ApiAuth', 'RateLimit', 'JsonResponse'])
+                ->withDefaults([
+                    'version' => 'v2',
+                    'format' => 'json'
+                ]);
+
+        $config = $builder->toArray();
+
+        // Verify all components
+        $this->assertEquals('api_resource_show', $builder->getName());
+        $this->assertEquals('\d+', $config['requirements']['id']);
+        $this->assertEquals(['GET', 'HEAD'], $config['conditions']['method']);
+        $this->assertEquals(['ApiAuth', 'RateLimit', 'JsonResponse'], $config['stack']);
+        $this->assertEquals('v2', $config['version']);
+        $this->assertEquals('json', $config['format']);
+
+        // Should build successfully
+        $route = $builder->build();
+        $this->assertInstanceOf(Route::class, $route);
+    }
+}

--- a/test/SecondaryRouteIntegrationTest.php
+++ b/test/SecondaryRouteIntegrationTest.php
@@ -1,0 +1,272 @@
+<?php
+/**
+ * Horde Routes package
+ *
+ * @author  Ralf Lang <lang@b1-systems.de>
+ * @license http://www.horde.org/licenses/bsd BSD
+ * @package Routes
+ */
+
+namespace Horde\Routes\Test;
+
+use PHPUnit\Framework\TestCase;
+use Horde\Routes\Mapper;
+
+/**
+ * Integration tests for secondary/legacy route feature
+ *
+ * @package Routes
+ * @group integration
+ */
+class SecondaryRouteIntegrationTest extends TestCase
+{
+    /**
+     * Test realistic scenario: multiple legacy URLs redirect to canonical
+     */
+    public function testLegacyUrlMigration(): void
+    {
+        $m = new Mapper();
+
+        // Modern canonical URLs
+        $m->connect('api_user_show', 'api/v2/users/:id', [
+            'controller' => 'Api\UserController',
+            'action' => 'show',
+            'requirements' => ['id' => '\d+']
+        ]);
+
+        // Legacy URLs from v1 API
+        $m->connectSecondary('api/v1/user/:id', [
+            'controller' => 'Api\UserController',
+            'action' => 'show',
+            'requirements' => ['id' => '\d+']
+        ]);
+
+        // Even older legacy URL
+        $m->connectSecondary('user.php', [
+            'controller' => 'Api\UserController',
+            'action' => 'show'
+        ]);
+
+        // Test all URLs match
+        $result1 = $m->match('/api/v2/users/123');
+        $this->assertIsArray($result1);
+        $this->assertEquals('Api\UserController', $result1['controller']);
+
+        $result2 = $m->match('/api/v1/user/123');
+        $this->assertIsArray($result2);
+        $this->assertEquals('Api\UserController', $result2['controller']);
+
+        $result3 = $m->match('/user.php');
+        $this->assertIsArray($result3);
+        $this->assertEquals('Api\UserController', $result3['controller']);
+
+        // Generation always uses canonical URL
+        $canonical = $m->generate([
+            'controller' => 'Api\UserController',
+            'action' => 'show',
+            'id' => '123'
+        ]);
+        $this->assertEquals('/api/v2/users/123', $canonical);
+    }
+
+    /**
+     * Test multiple alternative URLs for single endpoint
+     */
+    public function testMultipleAlternativesOneController(): void
+    {
+        $m = new Mapper();
+
+        // Primary route
+        $m->connect('dashboard', 'dashboard', [
+            'controller' => 'Dashboard',
+            'action' => 'index'
+        ]);
+
+        // Alternative URLs (marketing campaigns, shortcuts, etc.)
+        $m->connectSecondary('home', [
+            'controller' => 'Dashboard',
+            'action' => 'index'
+        ]);
+        $m->connectSecondary('index', [
+            'controller' => 'Dashboard',
+            'action' => 'index'
+        ]);
+        $m->connectSecondary('start', [
+            'controller' => 'Dashboard',
+            'action' => 'index'
+        ]);
+        $m->connectSecondary('welcome', [
+            'controller' => 'Dashboard',
+            'action' => 'index'
+        ]);
+        $m->connectSecondary('portal', [
+            'controller' => 'Dashboard',
+            'action' => 'index'
+        ]);
+
+        // All URLs should match
+        $paths = ['/dashboard', '/home', '/index', '/start', '/welcome', '/portal'];
+        foreach ($paths as $path) {
+            $result = $m->match($path);
+            $this->assertIsArray($result, "Failed to match: $path");
+            $this->assertEquals('Dashboard', $result['controller']);
+            $this->assertEquals('index', $result['action']);
+        }
+
+        // But only canonical generates
+        $url = $m->generate(['controller' => 'Dashboard', 'action' => 'index']);
+        $this->assertEquals('/dashboard', $url);
+    }
+
+    /**
+     * Test secondary routes with middleware stacks (PSR-15 pattern)
+     */
+    public function testSecondaryWithMiddlewareStack(): void
+    {
+        $m = new Mapper();
+
+        // Modern API endpoint with auth middleware
+        $m->connect('api/secure/data', [
+            'controller' => 'Api\SecureController',
+            'action' => 'getData',
+            'stack' => ['ApiAuth', 'RateLimit']
+        ]);
+
+        // Legacy endpoint (also requires same auth)
+        $m->connectSecondary('legacy/secure.php', [
+            'controller' => 'Api\SecureController',
+            'action' => 'getData',
+            'stack' => ['ApiAuth', 'RateLimit']
+        ]);
+
+        // Both should have middleware stack
+        $result1 = $m->match('/api/secure/data');
+        $this->assertIsArray($result1);
+        $this->assertArrayHasKey('stack', $result1);
+        $this->assertEquals(['ApiAuth', 'RateLimit'], $result1['stack']);
+
+        $result2 = $m->match('/legacy/secure.php');
+        $this->assertIsArray($result2);
+        $this->assertArrayHasKey('stack', $result2);
+        $this->assertEquals(['ApiAuth', 'RateLimit'], $result2['stack']);
+
+        // Generation uses primary
+        $url = $m->generate([
+            'controller' => 'Api\SecureController',
+            'action' => 'getData'
+        ]);
+        $this->assertEquals('/api/secure/data', $url);
+    }
+
+    /**
+     * Test route listing output format
+     */
+    public function testRouteListingFormat(): void
+    {
+        $m = new Mapper();
+
+        $m->connect('api_list', 'api/items', [
+            'controller' => 'Item',
+            'action' => 'list',
+            'conditions' => ['method' => 'GET']
+        ]);
+
+        $m->connectSecondary('items', [
+            'controller' => 'Item',
+            'action' => 'list',
+            'conditions' => ['method' => 'GET']
+        ]);
+
+        $m->connectSecondary('legacy_items_list', 'list.php', [
+            'controller' => 'Item',
+            'action' => 'list'
+        ]);
+
+        $routes = $m->getRouteList();
+
+        // Should have 3 routes
+        $this->assertCount(3, $routes);
+
+        // Check primary route
+        $this->assertEquals('primary', $routes[0]['type']);
+        $this->assertEquals('api/items', $routes[0]['path']);
+        $this->assertEquals('api_list', $routes[0]['name']);
+        $this->assertIsString($routes[0]['static']);  // Route->static is typed as string, not bool
+        $this->assertEquals('Item', $routes[0]['defaults']['controller']);
+
+        // Check first secondary
+        $this->assertEquals('secondary', $routes[1]['type']);
+        $this->assertEquals('items', $routes[1]['path']);
+        $this->assertNull($routes[1]['name']);
+
+        // Check named secondary
+        $this->assertEquals('secondary', $routes[2]['type']);
+        $this->assertEquals('list.php', $routes[2]['path']);
+        $this->assertEquals('legacy_items_list', $routes[2]['name']);
+    }
+
+    /**
+     * Test RESTful resource routes with secondary routes
+     */
+    public function testRESTfulWithSecondary(): void
+    {
+        $m = new Mapper();
+
+        // Modern RESTful routes
+        $m->connect('users', [
+            'controller' => 'User',
+            'action' => 'index',
+            'conditions' => ['method' => ['GET']]  // Must be array
+        ]);
+        $m->connect('users', [
+            'controller' => 'User',
+            'action' => 'create',
+            'conditions' => ['method' => ['POST']]  // Must be array
+        ]);
+        $m->connect('users/:id', [
+            'controller' => 'User',
+            'action' => 'show',
+            'conditions' => ['method' => ['GET']]  // Must be array
+        ]);
+
+        // Legacy routes (different URL patterns)
+        $m->connectSecondary('user/list', [
+            'controller' => 'User',
+            'action' => 'index'
+        ]);
+        $m->connectSecondary('user/:id/view', [
+            'controller' => 'User',
+            'action' => 'show'
+        ]);
+
+        // Modern GET /users should match
+        $m->environ = ['REQUEST_METHOD' => 'GET'];
+        $result1 = $m->match('/users');
+        $this->assertIsArray($result1);
+        $this->assertEquals('index', $result1['action']);
+
+        // Legacy GET /user/list should match
+        $result2 = $m->match('/user/list');
+        $this->assertIsArray($result2);
+        $this->assertEquals('index', $result2['action']);
+
+        // Modern GET /users/123 should match
+        $result3 = $m->match('/users/123');
+        $this->assertIsArray($result3);
+        $this->assertEquals('show', $result3['action']);
+        $this->assertEquals('123', $result3['id']);
+
+        // Legacy GET /user/123/view should match
+        $result4 = $m->match('/user/123/view');
+        $this->assertIsArray($result4);
+        $this->assertEquals('show', $result4['action']);
+        $this->assertEquals('123', $result4['id']);
+
+        // Generation uses primary routes
+        $url1 = $m->generate(['controller' => 'User', 'action' => 'index']);
+        $this->assertEquals('/users', $url1);
+
+        $url2 = $m->generate(['controller' => 'User', 'action' => 'show', 'id' => '123']);
+        $this->assertEquals('/users/123', $url2);
+    }
+}

--- a/test/SecondaryRouteTest.php
+++ b/test/SecondaryRouteTest.php
@@ -1,0 +1,268 @@
+<?php
+/**
+ * Horde Routes package
+ *
+ * @author  Ralf Lang <lang@b1-systems.de>
+ * @license http://www.horde.org/licenses/bsd BSD
+ * @package Routes
+ */
+
+namespace Horde\Routes\Test;
+
+use PHPUnit\Framework\TestCase;
+use Horde\Routes\Mapper;
+
+/**
+ * Tests for secondary/legacy route feature
+ *
+ * @package Routes
+ */
+class SecondaryRouteTest extends TestCase
+{
+    /**
+     * Test that secondary route matches incoming URL
+     */
+    public function testSecondaryRouteMatches(): void
+    {
+        $m = new Mapper();
+        $m->connect('api/users/:id', ['controller' => 'User', 'action' => 'show']);
+        $m->connectSecondary('user/:id', ['controller' => 'User', 'action' => 'show']);
+
+        // Both should match
+        $result1 = $m->match('/api/users/123');
+        $this->assertIsArray($result1);
+        $this->assertEquals('User', $result1['controller']);
+        $this->assertEquals('show', $result1['action']);
+        $this->assertEquals('123', $result1['id']);
+
+        $result2 = $m->match('/user/123');
+        $this->assertIsArray($result2);
+        $this->assertEquals('User', $result2['controller']);
+        $this->assertEquals('show', $result2['action']);
+        $this->assertEquals('123', $result2['id']);
+    }
+
+    /**
+     * Test that secondary route is NOT used for generation
+     */
+    public function testSecondaryRouteNotGenerated(): void
+    {
+        $m = new Mapper();
+        $m->connect('api/users/:id', ['controller' => 'User', 'action' => 'show']);
+        $m->connectSecondary('user/:id', ['controller' => 'User', 'action' => 'show']);
+
+        // Generation should only use primary route
+        $url = $m->generate(['controller' => 'User', 'action' => 'show', 'id' => '123']);
+        $this->assertEquals('/api/users/123', $url);
+
+        // Should NOT generate /user/123 (secondary route)
+        $this->assertNotEquals('/user/123', $url);
+    }
+
+    /**
+     * Test that primary route still generates correctly
+     */
+    public function testPrimaryRouteStillGenerates(): void
+    {
+        $m = new Mapper();
+        $m->connect('users/:id/profile', ['controller' => 'User', 'action' => 'show']);
+        $m->connectSecondary('profile/:id', ['controller' => 'User', 'action' => 'show']);
+        $m->connectSecondary('member/:id', ['controller' => 'User', 'action' => 'show']);
+
+        // Primary should be used for generation
+        $url = $m->generate(['controller' => 'User', 'action' => 'show', 'id' => '42']);
+        $this->assertEquals('/users/42/profile', $url);
+    }
+
+    /**
+     * Test multiple secondary routes for same controller
+     */
+    public function testMultipleSecondaryRoutes(): void
+    {
+        $m = new Mapper();
+        $m->connect('api/users/:id', ['controller' => 'User', 'action' => 'show']);
+        $m->connectSecondary('user/:id', ['controller' => 'User', 'action' => 'show']);
+        $m->connectSecondary('profile/:id', ['controller' => 'User', 'action' => 'show']);
+        $m->connectSecondary('member/:id', ['controller' => 'User', 'action' => 'show']);
+
+        // All should match
+        $this->assertNotNull($m->match('/api/users/123'));
+        $this->assertNotNull($m->match('/user/123'));
+        $this->assertNotNull($m->match('/profile/123'));
+        $this->assertNotNull($m->match('/member/123'));
+
+        // But only primary generates
+        $url = $m->generate(['controller' => 'User', 'action' => 'show', 'id' => '123']);
+        $this->assertEquals('/api/users/123', $url);
+    }
+
+    /**
+     * Test named secondary routes
+     */
+    public function testSecondaryNamedRoute(): void
+    {
+        $m = new Mapper();
+        $m->connect('user_profile', 'users/:id', ['controller' => 'User', 'action' => 'show']);
+        $m->connectSecondary('legacy_profile', 'profile/:id', ['controller' => 'User', 'action' => 'show']);
+
+        // Both should match
+        $this->assertNotNull($m->match('/users/123'));
+        $this->assertNotNull($m->match('/profile/123'));
+
+        // Generation should use primary
+        $url = $m->generate(['controller' => 'User', 'action' => 'show', 'id' => '123']);
+        $this->assertEquals('/users/123', $url);
+    }
+
+    /**
+     * Test secondary route with dynamic parameters
+     */
+    public function testSecondaryWithParameters(): void
+    {
+        $m = new Mapper();
+        $m->connect('posts/:year/:month/:slug', ['controller' => 'Post', 'action' => 'show']);
+        $m->connectSecondary('blog/:year/:month/:slug', ['controller' => 'Post', 'action' => 'show']);
+
+        // Secondary should extract parameters correctly
+        $result = $m->match('/blog/2024/03/hello-world');
+        $this->assertIsArray($result);
+        $this->assertEquals('2024', $result['year']);
+        $this->assertEquals('03', $result['month']);
+        $this->assertEquals('hello-world', $result['slug']);
+
+        // Primary should generate
+        $url = $m->generate([
+            'controller' => 'Post',
+            'action' => 'show',
+            'year' => '2024',
+            'month' => '03',
+            'slug' => 'hello-world'
+        ]);
+        $this->assertEquals('/posts/2024/03/hello-world', $url);
+    }
+
+    /**
+     * Test secondary route with requirements
+     */
+    public function testSecondaryWithRequirements(): void
+    {
+        $m = new Mapper();
+        $m->connect('api/users/:id', [
+            'controller' => 'User',
+            'action' => 'show',
+            'requirements' => ['id' => '\d+']
+        ]);
+        $m->connectSecondary('user/:id', [
+            'controller' => 'User',
+            'action' => 'show',
+            'requirements' => ['id' => '\d+']
+        ]);
+
+        // Numeric ID should match
+        $this->assertNotNull($m->match('/user/123'));
+
+        // Non-numeric ID should not match
+        $this->assertNull($m->match('/user/abc'));
+    }
+
+    /**
+     * Test secondary route with HTTP method conditions
+     */
+    public function testSecondaryWithConditions(): void
+    {
+        $m = new Mapper();
+        $m->connect('api/users/:id', [
+            'controller' => 'User',
+            'action' => 'show',
+            'conditions' => ['method' => ['GET']]  // Must be array
+        ]);
+        $m->connectSecondary('user/:id', [
+            'controller' => 'User',
+            'action' => 'show',
+            'conditions' => ['method' => ['GET']]  // Must be array
+        ]);
+
+        // GET should match (simulated via environ)
+        $m->environ = ['REQUEST_METHOD' => 'GET'];
+        $this->assertNotNull($m->match('/user/123'));
+
+        // POST should not match
+        $m->environ = ['REQUEST_METHOD' => 'POST'];
+        $this->assertNull($m->match('/user/123'));
+    }
+
+    /**
+     * Test getRouteList() includes secondary routes
+     */
+    public function testGetRouteListIncludesSecondary(): void
+    {
+        $m = new Mapper();
+        $m->connect('users/:id', ['controller' => 'User', 'action' => 'show']);
+        $m->connectSecondary('profile/:id', ['controller' => 'User', 'action' => 'show']);
+
+        $routes = $m->getRouteList();
+
+        $this->assertCount(2, $routes);
+        $this->assertEquals('primary', $routes[0]['type']);
+        $this->assertEquals('users/:id', $routes[0]['path']);
+        $this->assertEquals('secondary', $routes[1]['type']);
+        $this->assertEquals('profile/:id', $routes[1]['path']);
+    }
+
+    /**
+     * Test secondary routes appear in matchList
+     */
+    public function testSecondaryInMatchList(): void
+    {
+        $m = new Mapper();
+        $m->connect('api/users/:id', ['controller' => 'User', 'action' => 'show']);
+        $m->connectSecondary('user/:id', ['controller' => 'User', 'action' => 'show']);
+
+        $this->assertCount(2, $m->matchList);
+        $this->assertFalse($m->matchList[0]->secondary);
+        $this->assertTrue($m->matchList[1]->secondary);
+    }
+
+    /**
+     * Test connectSecondary with all argument variations
+     */
+    public function testConnectSecondaryArguments(): void
+    {
+        $m = new Mapper();
+
+        // 1 arg: path only
+        $m->connectSecondary('simple/path');
+        $this->assertTrue($m->matchList[0]->secondary);
+
+        // 2 args: path + kargs
+        $m->connectSecondary('path/:id', ['controller' => 'Test']);
+        $this->assertTrue($m->matchList[1]->secondary);
+        $this->assertEquals('Test', $m->matchList[1]->defaults['controller']);
+
+        // 2 args: name + path
+        $m->connectSecondary('test_route', 'named/path');
+        $this->assertTrue($m->matchList[2]->secondary);
+
+        // 3 args: name + path + kargs
+        $m->connectSecondary('test_route2', 'another/:id', ['action' => 'show']);
+        $this->assertTrue($m->matchList[3]->secondary);
+        $this->assertEquals('show', $m->matchList[3]->defaults['action']);
+    }
+
+    /**
+     * Test edge case: all routes are secondary (generation should fail gracefully)
+     */
+    public function testAllRoutesSecondary(): void
+    {
+        $m = new Mapper();
+        $m->connectSecondary('user/:id', ['controller' => 'User', 'action' => 'show']);
+        $m->connectSecondary('profile/:id', ['controller' => 'User', 'action' => 'show']);
+
+        // Matching should still work
+        $this->assertNotNull($m->match('/user/123'));
+
+        // Generation should return null (no primary routes)
+        $url = $m->generate(['controller' => 'User', 'action' => 'show', 'id' => '123']);
+        $this->assertNull($url);
+    }
+}


### PR DESCRIPTION
# Feature PR for horde/routes library

## feat(routes): Secondary Routes support and Route Analyzer

    Add secondary/legacy route feature that allows routes to match URLs
    without being used for generation. Useful for supporting alternative
    or legacy URLs without polluting the Named Route space with duplicates.

    Also provide a simple Route Builder interface for more robust route definition.
    A new Route Analyzer tool detects some cases of unreachable routes through conflicts.

    Design philosophy emphasizes no false positives. Incremental approach.
    New features are only available in the src/ branch and through the PSR-7 request interface.
    Legacy Horde_Controller interface is for BC only.

## feat(matcher): Set Request Method Verb from PSR-7 request

    Matcher now automatically sets mapper->environ['REQUEST_METHOD'] from
    request->getMethod(), eliminating manual environ setup when using PSR-7.

    Also handles legacy Horde_Controller_Request