### PR TITLE
feat: Implement GroupMapper, CompiledMatcher and CompiledGenerator

### DIFF
--- a/src/CompiledGenerator.php
+++ b/src/CompiledGenerator.php
@@ -1,0 +1,299 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2013-2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ */
+
+namespace Horde\Routes;
+
+/**
+ * Generates URLs from a precompiled route table (flat array from GroupMapper::dump()).
+ *
+ * @package Routes
+ */
+class CompiledGenerator
+{
+    /** @var array<int, array<string, mixed>> */
+    private array $routes;
+
+    /** @var array<string, int> */
+    private array $routeNames;
+
+    /** @var array<string, array<string, array{0: int[]}>> generation dict */
+    private array $gendict = [];
+
+    private bool $gensCreated = false;
+
+    /** @var array<string, string> */
+    private array $urlCache = [];
+
+    /**
+     * @param array{matchList: array, routeNames: array<string, int>} $compiled
+     */
+    public function __construct(array $compiled)
+    {
+        $this->routes = $compiled['matchList'];
+        $this->routeNames = $compiled['routeNames'];
+    }
+
+    /**
+     * Generate a URL by route name.
+     *
+     * @param string $routeName Named route identifier
+     * @param array<string, string> $params Parameters to fill placeholders
+     * @return string|null Generated URL or null
+     */
+    public function generateNamed(string $routeName, array $params = []): ?string
+    {
+        if (!isset($this->routeNames[$routeName])) {
+            return null;
+        }
+        $route = $this->routes[$this->routeNames[$routeName]];
+        return $this->generateFromRoute($route, $params);
+    }
+
+    /**
+     * Generate a URL from parameters (finds best matching route).
+     *
+     * @param array<string, string> $kargs Parameters including controller/action
+     * @return string|null Generated URL or null
+     */
+    public function generate(array $kargs): ?string
+    {
+        if (!$this->gensCreated) {
+            $this->createGens();
+        }
+
+        $cacheKey = serialize($kargs);
+        if (isset($this->urlCache[$cacheKey])) {
+            return $this->urlCache[$cacheKey];
+        }
+
+        $controller = $kargs['controller'] ?? '*';
+        $action = $kargs['action'] ?? '*';
+
+        $actionList = $this->gendict[$controller] ?? $this->gendict['*'] ?? [];
+        $indices = $actionList[$action][0] ?? $actionList['*'][0] ?? null;
+
+        if ($indices === null) {
+            return null;
+        }
+
+        $keys = array_keys($kargs);
+
+        // Filter to routes whose minKeys are satisfied
+        $candidates = [];
+        foreach ($indices as $idx) {
+            $route = $this->routes[$idx];
+            if (count(array_diff($route['minKeys'], $keys)) === 0) {
+                $candidates[] = $route;
+            }
+        }
+
+        // Sort: prefer routes matching more of our keys, then fewer maxKeys
+        usort($candidates, function (array $a, array $b) use ($keys) {
+            $ac = count(array_intersect($a['maxKeys'], $keys));
+            $bc = count(array_intersect($b['maxKeys'], $keys));
+            if ($ac === $bc) {
+                return count($a['maxKeys']) - count($b['maxKeys']);
+            }
+            return $bc - $ac;
+        });
+
+        foreach ($candidates as $route) {
+            $fail = false;
+            foreach ($route['hardCoded'] as $key) {
+                $kval = $kargs[$key] ?? null;
+                if ($kval === null) {
+                    continue;
+                }
+                if ($kval != $route['defaults'][$key]) {
+                    $fail = true;
+                    break;
+                }
+            }
+            if ($fail) {
+                continue;
+            }
+            $path = $this->generateFromRoute($route, $kargs);
+            if ($path !== null) {
+                $this->urlCache[$cacheKey] = $path;
+                return $path;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Generate URL from a single route's data.
+     */
+    private function generateFromRoute(array $route, array $kargs): ?string
+    {
+        $reqs = $route['reqs'] ?? [];
+
+        // Verify requirements
+        foreach ($reqs as $key => $pattern) {
+            $value = $kargs[$key] ?? null;
+            if ($value !== null && !preg_match('@^' . str_replace('@', '\@', $pattern) . '$@', $value)) {
+                return null;
+            }
+        }
+
+        // Check method condition
+        if (isset($kargs['method']) && isset($route['conditions']['method'])) {
+            if (!in_array(strtoupper($kargs['method']), $route['conditions']['method'])) {
+                return null;
+            }
+            unset($kargs['method']);
+        }
+
+        $routeList = $route['routeList'] ?? [];
+        $defaults = $route['defaults'] ?? [];
+        $maxKeys = $route['maxKeys'] ?? [];
+        $splitChars = ['/', ',', ';', '.', '#'];
+
+        // Build URL from routeList in reverse (same algorithm as Route::generate)
+        $routeBackwards = array_reverse($routeList);
+        $urlList = [];
+        $gaps = false;
+
+        foreach ($routeBackwards as $part) {
+            if (is_array($part) && $part['type'] === ':') {
+                $arg = $part['name'];
+                $hasArg = array_key_exists($arg, $kargs);
+                $hasDefault = array_key_exists($arg, $defaults);
+
+                if ($hasDefault && !$hasArg && !$gaps) {
+                    continue;
+                }
+                if ($hasDefault && $hasArg && $kargs[$arg] == $defaults[$arg] && !$gaps) {
+                    continue;
+                }
+                if ($hasArg && $kargs[$arg] === null && $hasDefault && !$gaps) {
+                    continue;
+                } elseif ($hasArg) {
+                    $val = $kargs[$arg] === null ? 'null' : $kargs[$arg];
+                } elseif ($hasDefault && $defaults[$arg] !== null) {
+                    $val = $defaults[$arg];
+                } else {
+                    return null;
+                }
+
+                $urlList[] = Utils::urlQuote((string) $val);
+                if ($hasArg) {
+                    unset($kargs[$arg]);
+                }
+                $gaps = true;
+            } elseif (is_array($part) && $part['type'] === '*') {
+                $arg = $part['name'];
+                $kar = $kargs[$arg] ?? null;
+                if ($kar !== null) {
+                    $urlList[] = Utils::urlQuote((string) $kar);
+                    $gaps = true;
+                }
+            } elseif (!empty($part) && in_array(substr($part, -1), $splitChars)) {
+                if (!$gaps && in_array($part, $splitChars)) {
+                    continue;
+                } elseif (!$gaps) {
+                    $gaps = true;
+                    $urlList[] = substr($part, 0, -1);
+                } else {
+                    $gaps = true;
+                    $urlList[] = $part;
+                }
+            } else {
+                $gaps = true;
+                $urlList[] = $part;
+            }
+        }
+
+        $urlList = array_reverse($urlList);
+        $url = implode('', $urlList);
+        if (!str_starts_with($url, '/')) {
+            $url = '/' . $url;
+        }
+
+        // Append extra params as query string
+        $extras = array_diff(array_keys($kargs), $maxKeys);
+        if (!empty($extras)) {
+            $queryParts = [];
+            foreach ($extras as $key) {
+                if ($key !== 'action' && $key !== 'controller') {
+                    $queryParts[$key] = $kargs[$key];
+                }
+            }
+            if (!empty($queryParts)) {
+                $url .= '?' . http_build_query($queryParts);
+            }
+        }
+
+        // Prepend path prefix
+        $pathPrefix = $route['pathPrefix'] ?? null;
+        if ($pathPrefix !== null) {
+            $url = $pathPrefix . $url;
+        }
+
+        return $url;
+    }
+
+    private function createGens(): void
+    {
+        $actionList = ['*' => true];
+        $controllerList = ['*' => true];
+
+        foreach ($this->routes as $idx => $route) {
+            if ($route['secondary'] ?? false) {
+                continue;
+            }
+            if (isset($route['defaults']['controller'])) {
+                $controllerList[$route['defaults']['controller']] = true;
+            }
+            if (isset($route['defaults']['action'])) {
+                $actionList[$route['defaults']['action']] = true;
+            }
+        }
+
+        $actionKeys = array_keys($actionList);
+        $controllerKeys = array_keys($controllerList);
+
+        $gendict = [];
+        foreach ($this->routes as $idx => $route) {
+            if ($route['secondary'] ?? false) {
+                continue;
+            }
+            $clist = $controllerKeys;
+            $alist = $actionKeys;
+            $hardCoded = $route['hardCoded'] ?? [];
+            $defaults = $route['defaults'] ?? [];
+
+            if (in_array('controller', $hardCoded)) {
+                $clist = [$defaults['controller']];
+            }
+            if (in_array('action', $hardCoded)) {
+                $alist = [$defaults['action']];
+            }
+            foreach ($clist as $controller) {
+                foreach ($alist as $action) {
+                    if (!isset($gendict[$controller])) {
+                        $gendict[$controller] = [];
+                    }
+                    if (!isset($gendict[$controller][$action])) {
+                        $gendict[$controller][$action] = [[]];
+                    }
+                    $gendict[$controller][$action][0][] = $idx;
+                }
+            }
+        }
+        if (!isset($gendict['*'])) {
+            $gendict['*'] = [];
+        }
+
+        $this->gendict = $gendict;
+        $this->gensCreated = true;
+    }
+}

--- a/src/CompiledMatcher.php
+++ b/src/CompiledMatcher.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2013-2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ */
+
+namespace Horde\Routes;
+
+/**
+ * Matches URLs against a precompiled route table (flat array from GroupMapper::dump()).
+ *
+ * No Route objects are instantiated at runtime. All matching happens against
+ * the plain array structure loaded from an opcached file.
+ *
+ * @package Routes
+ */
+class CompiledMatcher
+{
+    /** @var array<int, array<string, mixed>> */
+    private array $routes;
+
+    /**
+     * @param array{matchList: array, routeNames: array<string, int>} $compiled
+     */
+    public function __construct(array $compiled)
+    {
+        $this->routes = $compiled['matchList'];
+    }
+
+    /**
+     * Match a URL and return the match dict, or null.
+     *
+     * @param string $url URL path to match
+     * @param array<string, mixed> $environ Server environment (REQUEST_METHOD, HTTP_HOST, HTTPS, etc.)
+     */
+    public function match(string $url, array $environ = []): ?array
+    {
+        $result = $this->doMatch($url, $environ);
+        return $result !== null ? $result[0] : null;
+    }
+
+    /**
+     * Match a URL and return [matchDict, routeData] or null.
+     *
+     * @param string $url URL path to match
+     * @param array<string, mixed> $environ Server environment
+     * @return array{0: array<string, mixed>, 1: array<string, mixed>}|null
+     */
+    public function routematch(string $url, array $environ = []): ?array
+    {
+        return $this->doMatch($url, $environ);
+    }
+
+    /**
+     * @return array{0: array<string, mixed>, 1: array<string, mixed>}|null
+     */
+    private function doMatch(string $url, array $environ): ?array
+    {
+        foreach ($this->routes as $route) {
+            if ($route['secondary'] ?? false) {
+                // secondary routes participate in matching
+            }
+
+            $matchUrl = $url;
+
+            // Strip trailing slash
+            if (strlen($matchUrl) > 1 && str_ends_with($matchUrl, '/')) {
+                $matchUrl = substr($matchUrl, 0, -1);
+            }
+
+            // Path prefix check
+            $pathPrefix = $route['pathPrefix'] ?? null;
+            if ($pathPrefix !== null) {
+                if (!str_starts_with($matchUrl, $pathPrefix)) {
+                    continue;
+                }
+                $matchUrl = substr($matchUrl, strlen($pathPrefix)) ?: '/';
+                if (strlen($matchUrl) > 1 && str_ends_with($matchUrl, '/')) {
+                    $matchUrl = substr($matchUrl, 0, -1);
+                }
+            }
+
+            // Regexp match
+            $regexp = $route['regexp'] ?? '';
+            if ($regexp === '') {
+                continue;
+            }
+            $match = @preg_match('@' . str_replace('@', '\@', $regexp) . '@', $matchUrl, $matches);
+            if ($match === false || $match === 0) {
+                continue;
+            }
+
+            // Method condition
+            $conditions = $route['conditions'] ?? null;
+            if ($conditions !== null && isset($conditions['method'])) {
+                $requestMethod = $environ['REQUEST_METHOD'] ?? '';
+                if ($requestMethod === '' || !in_array($requestMethod, $conditions['method'])) {
+                    continue;
+                }
+            }
+
+            // Scheme check
+            $scheme = $route['scheme'] ?? null;
+            if ($scheme !== null) {
+                $isHttps = !empty($environ['HTTPS']) && $environ['HTTPS'] !== 'off';
+                $currentScheme = $isHttps ? 'https' : 'http';
+                if ($currentScheme !== $scheme) {
+                    continue;
+                }
+            }
+
+            // Host check
+            $host = $route['host'] ?? null;
+            if ($host !== null) {
+                $httpHost = $environ['HTTP_HOST'] ?? $environ['SERVER_NAME'] ?? '';
+                $hostOnly = explode(':', $httpHost)[0];
+                if (strcasecmp($hostOnly, $host) !== 0) {
+                    continue;
+                }
+            }
+
+            // Port check
+            $port = $route['port'] ?? null;
+            if ($port !== null) {
+                $httpHost = $environ['HTTP_HOST'] ?? '';
+                $parts = explode(':', $httpHost);
+                $currentPort = isset($parts[1]) ? (int) $parts[1] : (
+                    (!empty($environ['HTTPS']) && $environ['HTTPS'] !== 'off') ? 443 : 80
+                );
+                if ($currentPort !== $port) {
+                    continue;
+                }
+            }
+
+            // Build result from named captures + defaults
+            $defaults = $route['defaults'] ?? [];
+            $result = [];
+
+            // Extract named captures only
+            foreach ($matches as $key => $val) {
+                if (is_int($key)) {
+                    continue;
+                }
+                if ($val === '' && isset($defaults[$key]) && $defaults[$key] !== '') {
+                    $result[$key] = $defaults[$key];
+                } else {
+                    $result[$key] = urldecode($val);
+                }
+            }
+
+            // Fill in defaults not in matched URL
+            foreach ($defaults as $key => $val) {
+                if (!isset($result[$key])) {
+                    $result[$key] = $val;
+                }
+            }
+
+            // Include stack (always present in compiled routes from GroupMapper)
+            $stack = $route['stack'] ?? null;
+            if ($stack !== null) {
+                $result['stack'] = $stack;
+            }
+
+            // Function condition (callable stored in compiled — unlikely but support it)
+            if ($conditions !== null && isset($conditions['function'])) {
+                if (!call_user_func($conditions['function'], $environ, $result)) {
+                    continue;
+                }
+            }
+
+            return [$result, $route];
+        }
+
+        return null;
+    }
+}

--- a/src/GroupFluentRouteBuilder.php
+++ b/src/GroupFluentRouteBuilder.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2013-2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ */
+
+namespace Horde\Routes;
+
+/**
+ * Fluent wrapper for RouteBuilder that enables ->add() chaining with GroupMapper.
+ *
+ * @package Routes
+ */
+class GroupFluentRouteBuilder
+{
+    private GroupMapper $mapper;
+    private RouteBuilder $builder;
+
+    public function __construct(GroupMapper $mapper, RouteBuilder $builder)
+    {
+        $this->mapper = $mapper;
+        $this->builder = $builder;
+    }
+
+    public function getBuilder(): RouteBuilder
+    {
+        return $this->builder;
+    }
+
+    /**
+     * Build and add the route to the mapper, returning the mapper for chaining.
+     */
+    public function add(): GroupMapper
+    {
+        $this->mapper->addRoute($this->builder);
+        return $this->mapper;
+    }
+
+    /**
+     * Proxy all method calls to the underlying RouteBuilder.
+     *
+     * @return self|mixed
+     */
+    public function __call(string $method, array $args): mixed
+    {
+        $result = $this->builder->$method(...$args);
+        if ($result === $this->builder) {
+            return $this;
+        }
+        return $result;
+    }
+}

--- a/src/GroupMapper.php
+++ b/src/GroupMapper.php
@@ -1,0 +1,441 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2013-2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ */
+
+namespace Horde\Routes;
+
+use BadMethodCallException;
+
+/**
+ * Group-aware route mapper with definition-time resolution.
+ *
+ * Independent of the legacy Mapper class. Supports group(), buildRoute(),
+ * compile(), dump(). Does NOT support connect().
+ *
+ * Routes are fully resolved at definition time: group context (prefix, host,
+ * scheme, port, defaults, stack) is baked into the RouteBuilder before build().
+ * The resulting Route objects are self-contained and serializable.
+ *
+ * @package Routes
+ */
+class GroupMapper
+{
+    /** @var array<array<string, mixed>> */
+    private array $groupStack = [];
+
+    /** @var array<string> */
+    private array $defaultStack = [];
+
+    /** @var Route[] */
+    private array $matchList = [];
+
+    /** @var array<string, Route> */
+    private array $routeNames = [];
+
+    /** @var array<string, Route[]> keyed by serialized maxKeys */
+    private array $maxKeys = [];
+
+    private bool $compiled = false;
+
+    private bool $gensCreated = false;
+
+    /** @var array<string, array<string, array{Route[], mixed[]}>> */
+    private array $gendict = [];
+
+    /** @var array<string, string> */
+    private array $urlCache = [];
+
+    /** @var Route[] temp for _keysort */
+    private array $keysortKeys = [];
+
+    public array $environ = [];
+
+    public function __construct() {}
+
+    public function setDefaultStack(array $stack): void
+    {
+        $this->defaultStack = $stack;
+    }
+
+    /**
+     * Define a group of routes sharing common configuration.
+     *
+     * @param array{prefix?: string, host?: string, scheme?: string, port?: int, defaults?: array, stack?: array} $config
+     */
+    public function group(array $config, callable $fn): void
+    {
+        $this->groupStack[] = $config;
+        $fn($this);
+        array_pop($this->groupStack);
+    }
+
+    /**
+     * Start a fluent route definition. Group context is applied to the builder.
+     */
+    public function buildRoute(?string $uri = null, ?string $name = null): GroupFluentRouteBuilder
+    {
+        $merged = $this->mergedGroupConfig();
+
+        $prefix = $merged['prefix'];
+        $fullUri = $prefix . ($uri ?? '');
+
+        $builder = new RouteBuilder($fullUri);
+        if ($name !== null) {
+            $builder->withName($name);
+        }
+
+        if ($merged['host'] !== null) {
+            $builder->withHost($merged['host']);
+        }
+        if ($merged['scheme'] !== null) {
+            $builder->withScheme($merged['scheme']);
+        }
+        if ($merged['port'] !== null) {
+            $builder->withPort($merged['port']);
+        }
+        if (!empty($merged['defaults'])) {
+            $builder->withDefaults($merged['defaults']);
+        }
+
+        $stack = $merged['stack'] ?? $this->defaultStack;
+        if (!empty($stack)) {
+            $builder->withMiddleware($stack);
+        }
+
+        return new GroupFluentRouteBuilder($this, $builder);
+    }
+
+    /**
+     * Add a built route (or RouteBuilder) to this mapper.
+     */
+    public function addRoute(RouteBuilder|Route|array $routeOrBuilder): void
+    {
+        if ($routeOrBuilder instanceof RouteBuilder) {
+            $merged = $this->mergedGroupConfig();
+            $prefix = $merged['prefix'];
+            if ($prefix !== '') {
+                $routeOrBuilder->prefixSecondaryPaths($prefix);
+            }
+            $routes = $routeOrBuilder->build();
+            $routes = is_array($routes) ? $routes : [$routes];
+        } elseif (is_array($routeOrBuilder)) {
+            $routes = $routeOrBuilder;
+        } else {
+            $routes = [$routeOrBuilder];
+        }
+
+        foreach ($routes as $index => $route) {
+            $this->matchList[] = $route;
+            if ($index === 0 && $route->routeName !== null) {
+                $this->routeNames[$route->routeName] = $route;
+            }
+            if (!$route->secondary && !$route->static) {
+                $key = serialize($route->maxKeys);
+                if (isset($this->maxKeys[$key])) {
+                    $this->maxKeys[$key][] = $route;
+                } else {
+                    $this->maxKeys[$key] = [$route];
+                }
+            }
+        }
+        $this->compiled = false;
+        $this->gensCreated = false;
+    }
+
+    /**
+     * Legacy connect() is not supported. Throws with migration guidance.
+     */
+    public function connect(mixed ...$args): never
+    {
+        $parts = [];
+        foreach ($args as $arg) {
+            $parts[] = var_export($arg, true);
+        }
+        throw new BadMethodCallException(
+            'connect() is not supported by GroupMapper. Use buildRoute() instead. '
+            . 'Attempted: connect(' . implode(', ', $parts) . ')'
+        );
+    }
+
+    /**
+     * Compile all route regexps. Must be called before match/generate.
+     */
+    public function compile(): void
+    {
+        foreach ($this->maxKeys as $routes) {
+            foreach ($routes as $route) {
+                $route->makeRegexp([]);
+            }
+        }
+        foreach ($this->matchList as $route) {
+            if ($route->secondary && !$route->static) {
+                $route->makeRegexp([]);
+            }
+        }
+        $this->compiled = true;
+    }
+
+    /**
+     * Export the compiled route table as an opcacheable array.
+     *
+     * @return array{matchList: array, routeNames: array<string, int>}
+     */
+    public function dump(): array
+    {
+        if (!$this->compiled) {
+            $this->compile();
+        }
+        $matchList = [];
+        foreach ($this->matchList as $route) {
+            $matchList[] = $route->toArray();
+        }
+        $routeNames = [];
+        foreach ($this->routeNames as $name => $route) {
+            $idx = array_search($route, $this->matchList, true);
+            if ($idx !== false) {
+                $routeNames[$name] = $idx;
+            }
+        }
+        return ['matchList' => $matchList, 'routeNames' => $routeNames];
+    }
+
+    /**
+     * Match a URL. Returns the match dict or null.
+     */
+    public function match(string $url): ?array
+    {
+        if (!$this->compiled) {
+            $this->compile();
+        }
+
+        foreach ($this->matchList as $route) {
+            if ($route->static) {
+                continue;
+            }
+            $match = $route->match($url, [
+                'environ' => $this->environ,
+                'subDomains' => false,
+                'subDomainsIgnore' => [],
+                'domainMatch' => '[^\.\/]+?\.[^\.\/]+',
+            ]);
+            if ($match) {
+                return $match;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Match a URL, returning [matchDict, Route] or null.
+     */
+    public function routematch(string $url): ?array
+    {
+        if (!$this->compiled) {
+            $this->compile();
+        }
+
+        foreach ($this->matchList as $route) {
+            if ($route->static) {
+                continue;
+            }
+            $match = $route->match($url, [
+                'environ' => $this->environ,
+                'subDomains' => false,
+                'subDomainsIgnore' => [],
+                'domainMatch' => '[^\.\/]+?\.[^\.\/]+',
+            ]);
+            if ($match) {
+                return [$match, $route];
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Generate a URL from parameters.
+     *
+     * @param array<string, string> $kargs Route parameters
+     * @return string|null Generated URL or null
+     */
+    public function generate(array $kargs): ?string
+    {
+        if (!$this->gensCreated) {
+            $this->createGens();
+        }
+
+        $controller = $kargs['controller'] ?? '*';
+        $action = $kargs['action'] ?? '*';
+
+        $cacheKey = serialize($kargs);
+        if (isset($this->urlCache[$cacheKey])) {
+            return $this->urlCache[$cacheKey];
+        }
+
+        $actionList = $this->gendict[$controller] ?? $this->gendict['*'] ?? [];
+        $keyList = $actionList[$action][0] ?? $actionList['*'][0] ?? null;
+
+        if ($keyList === null) {
+            return null;
+        }
+
+        $keys = array_keys($kargs);
+        $this->keysortKeys = $keys;
+
+        $newList = [];
+        foreach ($keyList as $route) {
+            if (count(Utils::arraySubtract($route->minKeys, $keys)) === 0) {
+                $newList[] = $route;
+            }
+        }
+
+        usort($newList, function (Route $a, Route $b) {
+            $ac = count(array_intersect($a->maxKeys, $this->keysortKeys));
+            $bc = count(array_intersect($b->maxKeys, $this->keysortKeys));
+            if ($ac === $bc) {
+                return count($a->maxKeys) - count($b->maxKeys);
+            }
+            return $bc - $ac;
+        });
+
+        foreach ($newList as $route) {
+            $fail = false;
+            foreach ($route->hardCoded as $key) {
+                $kval = $kargs[$key] ?? null;
+                if ($kval === null) {
+                    continue;
+                }
+                if ($kval != $route->defaults[$key]) {
+                    $fail = true;
+                    break;
+                }
+            }
+            if ($fail) {
+                continue;
+            }
+            $path = $route->generate($kargs);
+            if ($path) {
+                $this->urlCache[$cacheKey] = $path;
+                return $path;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Get all registered routes (for debugging/inspection).
+     *
+     * @return Route[]
+     */
+    public function getMatchList(): array
+    {
+        return $this->matchList;
+    }
+
+    /**
+     * Get named routes.
+     *
+     * @return array<string, Route>
+     */
+    public function getRouteNames(): array
+    {
+        return $this->routeNames;
+    }
+
+    private function createGens(): void
+    {
+        $actionList = ['*' => true];
+        $controllerList = ['*' => true];
+
+        foreach ($this->matchList as $route) {
+            if ($route->static || $route->secondary) {
+                continue;
+            }
+            if (isset($route->defaults['controller'])) {
+                $controllerList[$route->defaults['controller']] = true;
+            }
+            if (isset($route->defaults['action'])) {
+                $actionList[$route->defaults['action']] = true;
+            }
+        }
+
+        $actionList = array_keys($actionList);
+        $controllerList = array_keys($controllerList);
+
+        $gendict = [];
+        foreach ($this->matchList as $route) {
+            if ($route->static || $route->secondary) {
+                continue;
+            }
+            $clist = $controllerList;
+            $alist = $actionList;
+            if (in_array('controller', $route->hardCoded)) {
+                $clist = [$route->defaults['controller']];
+            }
+            if (in_array('action', $route->hardCoded)) {
+                $alist = [$route->defaults['action']];
+            }
+            foreach ($clist as $controller) {
+                foreach ($alist as $action) {
+                    if (!isset($gendict[$controller])) {
+                        $gendict[$controller] = [];
+                    }
+                    if (!isset($gendict[$controller][$action])) {
+                        $gendict[$controller][$action] = [[], []];
+                    }
+                    $gendict[$controller][$action][0][] = $route;
+                }
+            }
+        }
+        if (!isset($gendict['*'])) {
+            $gendict['*'] = [];
+        }
+
+        $this->gendict = $gendict;
+        $this->gensCreated = true;
+    }
+
+    /**
+     * Merge all active group configs. Prefix concatenates, others: inner wins.
+     *
+     * @return array{prefix: string, host: ?string, scheme: ?string, port: ?int, defaults: array, stack: ?array}
+     */
+    private function mergedGroupConfig(): array
+    {
+        $merged = [
+            'prefix' => '',
+            'host' => null,
+            'scheme' => null,
+            'port' => null,
+            'defaults' => [],
+            'stack' => null,
+        ];
+        foreach ($this->groupStack as $group) {
+            if (isset($group['prefix'])) {
+                $merged['prefix'] .= $group['prefix'];
+            }
+            if (isset($group['host'])) {
+                $merged['host'] = $group['host'];
+            }
+            if (isset($group['scheme'])) {
+                $merged['scheme'] = $group['scheme'];
+            }
+            if (isset($group['port'])) {
+                $merged['port'] = $group['port'];
+            }
+            if (isset($group['defaults'])) {
+                $merged['defaults'] = array_merge($merged['defaults'], $group['defaults']);
+            }
+            if (isset($group['stack'])) {
+                $merged['stack'] = $group['stack'];
+            }
+        }
+        return $merged;
+    }
+}

--- a/src/Route.php
+++ b/src/Route.php
@@ -986,4 +986,31 @@ class Route
         $url = $this->generate($kargs);
         return $url !== null ? new Uri($url) : null;
     }
+
+    /**
+     * Export this route's state as a plain array suitable for opcache/serialization.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'routePath' => $this->routePath,
+            'regexp' => $this->regexp,
+            'defaults' => $this->defaults,
+            'reqs' => $this->reqs,
+            'conditions' => $this->conditions,
+            'host' => $this->host,
+            'scheme' => $this->scheme,
+            'port' => $this->port,
+            'pathPrefix' => $this->pathPrefix,
+            'stack' => $this->stack,
+            'secondary' => $this->secondary,
+            'routeName' => $this->routeName,
+            'maxKeys' => $this->maxKeys,
+            'minKeys' => $this->minKeys,
+            'hardCoded' => $this->hardCoded,
+            'routeList' => $this->routeList,
+        ];
+    }
 }

--- a/src/RouteBuilder.php
+++ b/src/RouteBuilder.php
@@ -191,6 +191,24 @@ class RouteBuilder
     }
 
     /**
+     * Prefix all registered secondary paths with the given string.
+     *
+     * Used by route mappers to prepend an application webroot to
+     * secondary paths before build() constructs Route objects.
+     *
+     * @param string $prefix Path prefix (e.g. "/appname")
+     * @return self
+     */
+    public function prefixSecondaryPaths(string $prefix): self
+    {
+        $prefix = rtrim($prefix, '/');
+        foreach ($this->secondaryPaths as $i => $path) {
+            $this->secondaryPaths[$i] = $prefix . '/' . ltrim($path, '/');
+        }
+        return $this;
+    }
+
+    /**
      * Set controller (PSR-style with* method)
      *
      * @param string $controller Controller name or class

--- a/test/CompiledRouteTest.php
+++ b/test/CompiledRouteTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Horde\Routes\Test;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Horde\Routes\GroupMapper;
+use Horde\Routes\CompiledMatcher;
+use Horde\Routes\CompiledGenerator;
+
+#[CoversClass(CompiledMatcher::class)]
+#[CoversClass(CompiledGenerator::class)]
+class CompiledRouteTest extends TestCase
+{
+    private array $compiled;
+
+    protected function setUp(): void
+    {
+        $m = new GroupMapper();
+        $m->setDefaultStack(['Auth', 'Log']);
+
+        $m->group(['prefix' => '/nag', 'defaults' => ['app' => 'nag']], function (GroupMapper $m) {
+            $m->buildRoute('/tasks', 'NagTaskList')
+                ->withController('TaskController')
+                ->withAction('list')
+                ->get()
+                ->add();
+            $m->buildRoute('/tasks', 'NagTaskCreate')
+                ->withController('TaskController')
+                ->withAction('create')
+                ->post()
+                ->add();
+            $m->buildRoute('/tasks/:id', 'NagTaskView')
+                ->withController('TaskController')
+                ->withAction('view')
+                ->add();
+        });
+
+        $m->group(['prefix' => '/api', 'stack' => ['ApiKey'], 'defaults' => ['app' => 'api']], function (GroupMapper $m) {
+            $m->buildRoute('/users/:id', 'ApiUserShow')
+                ->withController('ApiUserController')
+                ->withAction('show')
+                ->add();
+        });
+
+        $m->buildRoute('/health', 'Health')
+            ->withController('HealthController')
+            ->withAction('check')
+            ->noMiddleware()
+            ->add();
+
+        $this->compiled = $m->dump();
+    }
+
+    #[Test]
+    public function matcherFindsRoute(): void
+    {
+        $matcher = new CompiledMatcher($this->compiled);
+        $result = $matcher->match('/nag/tasks/42');
+
+        $this->assertIsArray($result);
+        $this->assertSame('TaskController', $result['controller']);
+        $this->assertSame('view', $result['action']);
+        $this->assertSame('42', $result['id']);
+        $this->assertSame('nag', $result['app']);
+        $this->assertSame(['Auth', 'Log'], $result['stack']);
+    }
+
+    #[Test]
+    public function matcherRespectsMethodCondition(): void
+    {
+        $matcher = new CompiledMatcher($this->compiled);
+
+        // GET matches list
+        $result = $matcher->match('/nag/tasks', ['REQUEST_METHOD' => 'GET']);
+        $this->assertIsArray($result);
+        $this->assertSame('list', $result['action']);
+
+        // POST matches create
+        $result = $matcher->match('/nag/tasks', ['REQUEST_METHOD' => 'POST']);
+        $this->assertIsArray($result);
+        $this->assertSame('create', $result['action']);
+    }
+
+    #[Test]
+    public function matcherReturnsCustomStack(): void
+    {
+        $matcher = new CompiledMatcher($this->compiled);
+        $result = $matcher->match('/api/users/5');
+
+        $this->assertSame(['ApiKey'], $result['stack']);
+        $this->assertSame('api', $result['app']);
+    }
+
+    #[Test]
+    public function matcherReturnsEmptyStackForNoMiddleware(): void
+    {
+        $matcher = new CompiledMatcher($this->compiled);
+        $result = $matcher->match('/health');
+
+        $this->assertSame([], $result['stack']);
+    }
+
+    #[Test]
+    public function matcherReturnsNullForNoMatch(): void
+    {
+        $matcher = new CompiledMatcher($this->compiled);
+        $this->assertNull($matcher->match('/nonexistent'));
+    }
+
+    #[Test]
+    public function routematchReturnsRouteData(): void
+    {
+        $matcher = new CompiledMatcher($this->compiled);
+        $result = $matcher->routematch('/nag/tasks/1');
+
+        $this->assertIsArray($result);
+        $this->assertCount(2, $result);
+        [$dict, $routeData] = $result;
+        $this->assertSame('TaskController', $dict['controller']);
+        $this->assertSame('NagTaskView', $routeData['routeName']);
+    }
+
+    #[Test]
+    public function generatorByName(): void
+    {
+        $gen = new CompiledGenerator($this->compiled);
+        $url = $gen->generateNamed('NagTaskView', ['id' => '99']);
+
+        $this->assertSame('/nag/tasks/99', $url);
+    }
+
+    #[Test]
+    public function generatorByParams(): void
+    {
+        $gen = new CompiledGenerator($this->compiled);
+        $url = $gen->generate([
+            'controller' => 'ApiUserController',
+            'action' => 'show',
+            'id' => '7',
+        ]);
+
+        $this->assertSame('/api/users/7', $url);
+    }
+
+    #[Test]
+    public function generatorReturnsNullForUnknownName(): void
+    {
+        $gen = new CompiledGenerator($this->compiled);
+        $this->assertNull($gen->generateNamed('NonexistentRoute'));
+    }
+
+    #[Test]
+    public function generatorReturnsNullForUnmatchableParams(): void
+    {
+        $gen = new CompiledGenerator($this->compiled);
+        $this->assertNull($gen->generate([
+            'controller' => 'Unknown',
+            'action' => 'missing',
+        ]));
+    }
+
+    #[Test]
+    public function roundTripMatchAndGenerate(): void
+    {
+        $matcher = new CompiledMatcher($this->compiled);
+        $gen = new CompiledGenerator($this->compiled);
+
+        // Match a URL
+        $result = $matcher->match('/nag/tasks/55');
+        $this->assertSame('55', $result['id']);
+
+        // Generate it back
+        $url = $gen->generate([
+            'controller' => $result['controller'],
+            'action' => $result['action'],
+            'id' => $result['id'],
+        ]);
+        $this->assertSame('/nag/tasks/55', $url);
+    }
+}

--- a/test/GroupMapperTest.php
+++ b/test/GroupMapperTest.php
@@ -1,0 +1,344 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Horde\Routes\Test;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Horde\Routes\GroupMapper;
+use Horde\Routes\GroupFluentRouteBuilder;
+use Horde\Routes\Route;
+use BadMethodCallException;
+
+#[CoversClass(GroupMapper::class)]
+#[CoversClass(GroupFluentRouteBuilder::class)]
+class GroupMapperTest extends TestCase
+{
+    #[Test]
+    public function buildRouteWithoutGroup(): void
+    {
+        $m = new GroupMapper();
+        $m->buildRoute('/users/:id')
+            ->withController('UserController')
+            ->withAction('show')
+            ->add();
+        $m->compile();
+
+        $result = $m->match('/users/42');
+        $this->assertIsArray($result);
+        $this->assertSame('UserController', $result['controller']);
+        $this->assertSame('show', $result['action']);
+        $this->assertSame('42', $result['id']);
+    }
+
+    #[Test]
+    public function groupAppliesPrefix(): void
+    {
+        $m = new GroupMapper();
+        $m->group(['prefix' => '/nag'], function (GroupMapper $m) {
+            $m->buildRoute('/tasks/:id')
+                ->withController('TaskController')
+                ->withAction('view')
+                ->add();
+        });
+        $m->compile();
+
+        $result = $m->match('/nag/tasks/7');
+        $this->assertIsArray($result);
+        $this->assertSame('TaskController', $result['controller']);
+        $this->assertSame('7', $result['id']);
+
+        // Without prefix should NOT match
+        $this->assertNull($m->match('/tasks/7'));
+    }
+
+    #[Test]
+    public function groupAppliesDefaults(): void
+    {
+        $m = new GroupMapper();
+        $m->group(['prefix' => '/nag', 'defaults' => ['app' => 'nag']], function (GroupMapper $m) {
+            $m->buildRoute('/tasks/:id')
+                ->withController('TaskController')
+                ->withAction('view')
+                ->add();
+        });
+        $m->compile();
+
+        $result = $m->match('/nag/tasks/1');
+        $this->assertSame('nag', $result['app']);
+    }
+
+    #[Test]
+    public function groupAppliesStack(): void
+    {
+        $m = new GroupMapper();
+        $m->group(['prefix' => '/app', 'stack' => ['Auth', 'Log']], function (GroupMapper $m) {
+            $m->buildRoute('/page')
+                ->withController('PageController')
+                ->withAction('index')
+                ->add();
+        });
+        $m->compile();
+
+        $result = $m->match('/app/page');
+        $this->assertSame(['Auth', 'Log'], $result['stack']);
+    }
+
+    #[Test]
+    public function builderOverridesGroupStack(): void
+    {
+        $m = new GroupMapper();
+        $m->group(['prefix' => '/app', 'stack' => ['Auth', 'Log']], function (GroupMapper $m) {
+            $m->buildRoute('/api/data')
+                ->withController('ApiController')
+                ->withAction('get')
+                ->withMiddleware(['ApiKey'])
+                ->add();
+        });
+        $m->compile();
+
+        $result = $m->match('/app/api/data');
+        $this->assertSame(['ApiKey'], $result['stack']);
+    }
+
+    #[Test]
+    public function noMiddlewareOverridesGroupStack(): void
+    {
+        $m = new GroupMapper();
+        $m->group(['prefix' => '/app', 'stack' => ['Auth', 'Log']], function (GroupMapper $m) {
+            $m->buildRoute('/health')
+                ->withController('HealthController')
+                ->withAction('check')
+                ->noMiddleware()
+                ->add();
+        });
+        $m->compile();
+
+        $result = $m->match('/app/health');
+        $this->assertSame([], $result['stack']);
+    }
+
+    #[Test]
+    public function defaultStackAppliesWhenNoGroupStack(): void
+    {
+        $m = new GroupMapper();
+        $m->setDefaultStack(['DefaultMw']);
+        $m->buildRoute('/open')
+            ->withController('OpenController')
+            ->withAction('index')
+            ->add();
+        $m->compile();
+
+        $result = $m->match('/open');
+        $this->assertSame(['DefaultMw'], $result['stack']);
+    }
+
+    #[Test]
+    public function nestedGroupsPrefixConcatenates(): void
+    {
+        $m = new GroupMapper();
+        $m->group(['prefix' => '/nag'], function (GroupMapper $m) {
+            $m->group(['prefix' => '/api'], function (GroupMapper $m) {
+                $m->buildRoute('/tasks/:id')
+                    ->withController('ApiTaskController')
+                    ->withAction('get')
+                    ->add();
+            });
+        });
+        $m->compile();
+
+        $result = $m->match('/nag/api/tasks/5');
+        $this->assertIsArray($result);
+        $this->assertSame('ApiTaskController', $result['controller']);
+        $this->assertSame('5', $result['id']);
+    }
+
+    #[Test]
+    public function nestedGroupInnerStackOverridesOuter(): void
+    {
+        $m = new GroupMapper();
+        $m->group(['prefix' => '/app', 'stack' => ['Auth']], function (GroupMapper $m) {
+            $m->group(['prefix' => '/api', 'stack' => ['ApiKey']], function (GroupMapper $m) {
+                $m->buildRoute('/data')
+                    ->withController('DataController')
+                    ->withAction('list')
+                    ->add();
+            });
+        });
+        $m->compile();
+
+        $result = $m->match('/app/api/data');
+        $this->assertSame(['ApiKey'], $result['stack']);
+    }
+
+    #[Test]
+    public function nestedGroupDefaultsMerge(): void
+    {
+        $m = new GroupMapper();
+        $m->group(['prefix' => '/nag', 'defaults' => ['app' => 'nag']], function (GroupMapper $m) {
+            $m->group(['defaults' => ['format' => 'json']], function (GroupMapper $m) {
+                $m->buildRoute('/tasks')
+                    ->withController('TaskController')
+                    ->withAction('list')
+                    ->add();
+            });
+        });
+        $m->compile();
+
+        $result = $m->match('/nag/tasks');
+        $this->assertSame('nag', $result['app']);
+        $this->assertSame('json', $result['format']);
+    }
+
+    #[Test]
+    public function connectThrowsWithMessage(): void
+    {
+        $m = new GroupMapper();
+        $this->expectException(BadMethodCallException::class);
+        $this->expectExceptionMessageMatches('/connect\(\) is not supported/');
+        $m->connect('/users/:id', ['controller' => 'User']);
+    }
+
+    #[Test]
+    public function groupAppliesHostSchemePort(): void
+    {
+        $m = new GroupMapper();
+        $m->group([
+            'prefix' => '/secure',
+            'host' => 'admin.example.com',
+            'scheme' => 'https',
+            'port' => 8443,
+        ], function (GroupMapper $m) {
+            $m->buildRoute('/panel')
+                ->withController('AdminController')
+                ->withAction('index')
+                ->add();
+        });
+        $m->compile();
+
+        // Correct environ matches
+        $m->environ = [
+            'HTTP_HOST' => 'admin.example.com:8443',
+            'HTTPS' => 'on',
+            'REQUEST_METHOD' => 'GET',
+        ];
+        $result = $m->match('/secure/panel');
+        $this->assertIsArray($result);
+        $this->assertSame('AdminController', $result['controller']);
+
+        // Wrong host doesn't match
+        $m->environ = [
+            'HTTP_HOST' => 'other.example.com:8443',
+            'HTTPS' => 'on',
+            'REQUEST_METHOD' => 'GET',
+        ];
+        $this->assertNull($m->match('/secure/panel'));
+    }
+
+    #[Test]
+    public function routematchReturnsRouteObject(): void
+    {
+        $m = new GroupMapper();
+        $m->buildRoute('/test', 'TestRoute')
+            ->withController('TestController')
+            ->withAction('index')
+            ->add();
+        $m->compile();
+
+        $result = $m->routematch('/test');
+        $this->assertIsArray($result);
+        $this->assertCount(2, $result);
+        [$dict, $route] = $result;
+        $this->assertSame('TestController', $dict['controller']);
+        $this->assertInstanceOf(Route::class, $route);
+        $this->assertSame('TestRoute', $route->routeName);
+    }
+
+    #[Test]
+    public function generateProducesUrl(): void
+    {
+        $m = new GroupMapper();
+        $m->group(['prefix' => '/nag'], function (GroupMapper $m) {
+            $m->buildRoute('/tasks/:id')
+                ->withController('TaskController')
+                ->withAction('view')
+                ->add();
+        });
+        $m->compile();
+
+        $url = $m->generate(['controller' => 'TaskController', 'action' => 'view', 'id' => '99']);
+        $this->assertSame('/nag/tasks/99', $url);
+    }
+
+    #[Test]
+    public function secondaryPathsPrefixedByGroup(): void
+    {
+        $m = new GroupMapper();
+        $m->group(['prefix' => '/nag'], function (GroupMapper $m) {
+            $m->buildRoute('/tasks/:id')
+                ->withController('TaskController')
+                ->withAction('view')
+                ->withSecondaryRoute('/legacy/:id')
+                ->add();
+        });
+        $m->compile();
+
+        // Primary matches
+        $this->assertIsArray($m->match('/nag/tasks/5'));
+
+        // Secondary should be prefixed with /nag
+        $result = $m->match('/nag/legacy/5');
+        $this->assertIsArray($result);
+        $this->assertSame('5', $result['id']);
+
+        // Unprefixed secondary should NOT match
+        $this->assertNull($m->match('/legacy/5'));
+    }
+
+    #[Test]
+    public function dumpProducesArray(): void
+    {
+        $m = new GroupMapper();
+        $m->setDefaultStack(['Mw1', 'Mw2']);
+        $m->group(['prefix' => '/app', 'defaults' => ['app' => 'myapp']], function (GroupMapper $m) {
+            $m->buildRoute('/page/:id', 'AppPage')
+                ->withController('PageController')
+                ->withAction('show')
+                ->add();
+        });
+
+        $dumped = $m->dump();
+
+        $this->assertArrayHasKey('matchList', $dumped);
+        $this->assertArrayHasKey('routeNames', $dumped);
+        $this->assertCount(1, $dumped['matchList']);
+        $this->assertSame(0, $dumped['routeNames']['AppPage']);
+
+        $route = $dumped['matchList'][0];
+        $this->assertSame('/app/page/:id', $route['routePath']);
+        $this->assertSame('PageController', $route['defaults']['controller']);
+        $this->assertSame('myapp', $route['defaults']['app']);
+        $this->assertSame(['Mw1', 'Mw2'], $route['stack']);
+        $this->assertNotEmpty($route['regexp']);
+    }
+
+    #[Test]
+    public function methodConditionsRespected(): void
+    {
+        $m = new GroupMapper();
+        $m->buildRoute('/submit')
+            ->withController('FormController')
+            ->withAction('process')
+            ->post()
+            ->add();
+        $m->compile();
+
+        $m->environ = ['REQUEST_METHOD' => 'POST'];
+        $this->assertIsArray($m->match('/submit'));
+
+        $m->environ = ['REQUEST_METHOD' => 'GET'];
+        $this->assertNull($m->match('/submit'));
+    }
+}

--- a/test/SecondaryRouteTest.php
+++ b/test/SecondaryRouteTest.php
@@ -12,6 +12,7 @@ namespace Horde\Routes\Test;
 
 use PHPUnit\Framework\TestCase;
 use Horde\Routes\Mapper;
+use Horde\Routes\RouteBuilder;
 
 /**
  * Tests for secondary/legacy route feature
@@ -300,5 +301,103 @@ class SecondaryRouteTest extends TestCase
         // Generation should return null (no primary routes)
         $url = $m->generate(['controller' => 'User', 'action' => 'show', 'id' => '123']);
         $this->assertNull($url);
+    }
+
+    /**
+     * Test prefixSecondaryPaths prepends prefix to all secondary paths
+     */
+    public function testPrefixSecondaryPaths(): void
+    {
+        $builder = new RouteBuilder('/primary/:id');
+        $builder->withController('User')
+            ->withAction('show')
+            ->withSecondaryRoute('alt/:id')
+            ->withSecondaryRoute('other/:id')
+            ->prefixSecondaryPaths('/app');
+
+        $routes = $builder->build();
+
+        $this->assertIsArray($routes);
+        $this->assertCount(3, $routes);
+        // Primary route unchanged
+        $this->assertSame('/primary/:id', $routes[0]->routePath);
+        // Secondary routes prefixed
+        $this->assertSame('/app/alt/:id', $routes[1]->routePath);
+        $this->assertSame('/app/other/:id', $routes[2]->routePath);
+    }
+
+    /**
+     * Test prefixSecondaryPaths with trailing slash on prefix
+     */
+    public function testPrefixSecondaryPathsTrimsTrailingSlash(): void
+    {
+        $builder = new RouteBuilder('/primary');
+        $builder->withController('Test')
+            ->withSecondaryRoute('legacy/path')
+            ->prefixSecondaryPaths('/app/');
+
+        $routes = $builder->build();
+
+        $this->assertIsArray($routes);
+        $this->assertSame('/app/legacy/path', $routes[1]->routePath);
+    }
+
+    /**
+     * Test prefixSecondaryPaths with leading slash on secondary path
+     */
+    public function testPrefixSecondaryPathsHandlesLeadingSlash(): void
+    {
+        $builder = new RouteBuilder('/primary');
+        $builder->withController('Test')
+            ->withSecondaryRoute('/already/slashed')
+            ->prefixSecondaryPaths('/app');
+
+        $routes = $builder->build();
+
+        $this->assertIsArray($routes);
+        $this->assertSame('/app/already/slashed', $routes[1]->routePath);
+    }
+
+    /**
+     * Test prefixSecondaryPaths with no secondary routes is a no-op
+     */
+    public function testPrefixSecondaryPathsNoSecondaryRoutes(): void
+    {
+        $builder = new RouteBuilder('/primary');
+        $builder->withController('Test')
+            ->prefixSecondaryPaths('/app');
+
+        $route = $builder->build();
+
+        // No secondary routes means single Route returned, not array
+        $this->assertInstanceOf(\Horde\Routes\Route::class, $route);
+        $this->assertSame('/primary', $route->routePath);
+    }
+
+    /**
+     * Test prefixed secondary routes still match correctly in Mapper
+     */
+    public function testPrefixedSecondaryRoutesMatch(): void
+    {
+        $m = new Mapper();
+        $builder = $m->buildRoute(uri: 'api/users/:id')
+            ->withController('User')
+            ->withAction('show')
+            ->withSecondaryRoute('user/:id');
+        $builder->prefixSecondaryPaths('/myapp');
+        $builder->add();
+
+        // Primary still matches
+        $result = $m->match('/api/users/42');
+        $this->assertIsArray($result);
+        $this->assertEquals('42', $result['id']);
+
+        // Prefixed secondary matches
+        $result = $m->match('/myapp/user/42');
+        $this->assertIsArray($result);
+        $this->assertEquals('42', $result['id']);
+
+        // Unprefixed secondary should NOT match
+        $this->assertNull($m->match('/user/42'));
     }
 }


### PR DESCRIPTION
GroupMapper supports defining groups of routes which have different defaults and prefixes (but no ties to horde/core assumptions) This shares a minimal common interface with the classic mapper but doesn't support ->connect syntax and some other legacy features. The original mapper remains unchanged.